### PR TITLE
fix: correct middleware and once handler behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/PlutoWu-Cn/go-bus.svg)](https://pkg.go.dev/github.com/PlutoWu-Cn/go-bus)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/PlutoWu-Cn/go-bus)](https://goreportcard.com/report/github.com/PlutoWu-Cn/go-bus)
-[![Coverage](https://img.shields.io/badge/coverage-92.2%25-brightgreen.svg)](https://github.com/PlutoWu-Cn/go-bus)
+[![Coverage](https://img.shields.io/badge/coverage-92.3%25-brightgreen.svg)](https://github.com/PlutoWu-Cn/go-bus)
 
 
 
@@ -254,7 +254,7 @@ type BusPublisher[T any] interface {
 
 // Controller interface
 type BusController interface {
-    GetMetrics() *EventMetrics
+    GetMetrics() Metrics
     SetErrorHandler(handler ErrorHandler)
     AddMiddleware(middleware EventMiddleware[any])
     Close() error
@@ -398,7 +398,7 @@ go test -coverprofile=coverage.out ./...
 go tool cover -html=coverage.out -o coverage.html
 ```
 
-**Current test coverage: 92.2%** - We maintain high test coverage to ensure reliability and stability.
+**Current test coverage: 92.3%** - We maintain high test coverage to ensure reliability and stability.
 
 Run performance benchmarks:
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -11,7 +11,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/PlutoWu-Cn/go-bus.svg)](https://pkg.go.dev/github.com/PlutoWu-Cn/go-bus)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/PlutoWu-Cn/go-bus)](https://goreportcard.com/report/github.com/PlutoWu-Cn/go-bus)
-[![Coverage](https://img.shields.io/badge/coverage-92.2%25-brightgreen.svg)](https://github.com/PlutoWu-Cn/go-bus)
+[![Coverage](https://img.shields.io/badge/coverage-92.3%25-brightgreen.svg)](https://github.com/PlutoWu-Cn/go-bus)
 
 
 
@@ -254,7 +254,7 @@ type BusPublisher[T any] interface {
 
 // 控制器接口
 type BusController interface {
-    GetMetrics() *EventMetrics
+    GetMetrics() Metrics
     SetErrorHandler(handler ErrorHandler)
     AddMiddleware(middleware EventMiddleware[any])
     Close() error
@@ -398,7 +398,7 @@ go test -coverprofile=coverage.out ./...
 go tool cover -html=coverage.out -o coverage.html
 ```
 
-**当前测试覆盖率：92.2%** - 我们保持高测试覆盖率以确保可靠性和稳定性。
+**当前测试覆盖率：92.3%** - 我们保持高测试覆盖率以确保可靠性和稳定性。
 
 运行性能测试：
 

--- a/bus.go
+++ b/bus.go
@@ -291,11 +291,13 @@ func (bus *EventBus[T]) Publish(topic string, event T) {
 // PublishWithContext publishes an event with context
 func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, event T) error {
 	bus.lock.RLock()
-	defer bus.lock.RUnlock()
-
 	if bus.closed {
+		bus.lock.RUnlock()
 		return fmt.Errorf("event bus is closed")
 	}
+	handlers := append([]*eventHandler[T](nil), bus.handlers[topic]...)
+	middlewares := append([]EventMiddleware[any](nil), bus.middlewares...)
+	bus.lock.RUnlock()
 
 	// Log event publishing
 	if bus.logger != nil {
@@ -304,108 +306,120 @@ func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, ev
 
 	bus.metrics.IncrementPublished()
 
-	// Apply middlewares
-	for _, middleware := range bus.middlewares {
-		if err := middleware(topic, event, func() {}); err != nil {
-			if bus.errorHandler != nil {
-				bus.errorHandler(&EventError{
-					Topic: topic,
-					Event: event,
-					Err:   err,
-				})
-			}
-			return err
-		}
+	runHandlers := func() error {
+		return bus.publishHandlers(ctx, topic, event, handlers)
+	}
+	var publishErr error
+	var middlewareErr error
+	next := func() {
+		publishErr = runHandlers()
 	}
 
-	if handlers, ok := bus.handlers[topic]; ok && 0 < len(handlers) {
-		// Create a copy to avoid modification during iteration
-		copyHandlers := make([]*eventHandler[T], len(handlers))
-		copy(copyHandlers, handlers)
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		middleware := middlewares[i]
+		prev := next
+		next = func() {
+			if publishErr == nil {
+				if err := middleware(topic, event, prev); err != nil {
+					middlewareErr = err
+					publishErr = err
+				}
+			}
+		}
+	}
+	next()
 
-		// Check if we have a deadline (timeout)
-		_, hasDeadline := ctx.Deadline()
+	if publishErr != nil {
+		if middlewareErr != nil && bus.errorHandler != nil {
+			bus.errorHandler(&EventError{
+				Topic: topic,
+				Event: event,
+				Err:   middlewareErr,
+			})
+		}
+		return publishErr
+	}
 
-		for i, handler := range copyHandlers {
-			// Check context cancellation
+	return nil
+}
+
+func (bus *EventBus[T]) publishHandlers(ctx context.Context, topic string, event T, handlers []*eventHandler[T]) error {
+	_, hasDeadline := ctx.Deadline()
+
+	for _, handler := range handlers {
+		handler := handler
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-bus.closeCh:
+			return fmt.Errorf("event bus is closed")
+		default:
+		}
+
+		if handler.ctx != nil {
 			select {
+			case <-handler.ctx.Done():
+				continue
+			default:
+			}
+		}
+
+		if handler.filter != nil && !handler.filter(topic, event) {
+			continue
+		}
+
+		if handler.flagOnce {
+			bus.removeHandler(topic, handler)
+		}
+
+		if !handler.async {
+			if !hasDeadline {
+				bus.doPublish(handler, topic, event)
+				continue
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						if bus.errorHandler != nil {
+							bus.errorHandler(&EventError{
+								Topic:   topic,
+								Event:   event,
+								Handler: handler.callBack,
+								Err:     fmt.Errorf("panic: %v", r),
+							})
+						}
+						bus.metrics.IncrementFailed()
+						done <- fmt.Errorf("panic: %v", r)
+						return
+					}
+					bus.metrics.IncrementProcessed()
+					done <- nil
+				}()
+				handler.callBack(event)
+			}()
+
+			select {
+			case err := <-done:
+				if err != nil {
+					return err
+				}
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-bus.closeCh:
 				return fmt.Errorf("event bus is closed")
-			default:
 			}
-
-			// Check handler context
-			if handler.ctx != nil {
-				select {
-				case <-handler.ctx.Done():
-					continue // Skip this handler
-				default:
-				}
-			}
-
-			// Apply filter if present
-			if handler.filter != nil && !handler.filter(topic, event) {
-				continue
-			}
-
-			if handler.flagOnce {
-				bus.removeHandler(topic, i)
-			}
-
-			if !handler.async {
-				if hasDeadline {
-					// For synchronous handlers with timeout, run in a goroutine
-					done := make(chan error, 1)
-
-					go func() {
-						defer func() {
-							if r := recover(); r != nil {
-								if bus.errorHandler != nil {
-									bus.errorHandler(&EventError{
-										Topic:   topic,
-										Event:   event,
-										Handler: handler.callBack,
-										Err:     fmt.Errorf("panic: %v", r),
-									})
-								}
-								bus.metrics.IncrementFailed()
-								done <- fmt.Errorf("panic: %v", r)
-							} else {
-								bus.metrics.IncrementProcessed()
-								done <- nil
-							}
-						}()
-						handler.callBack(event)
-					}()
-
-					select {
-					case err := <-done:
-						if err != nil {
-							return err
-						}
-					case <-ctx.Done():
-						return ctx.Err()
-					case <-bus.closeCh:
-						return fmt.Errorf("event bus is closed")
-					}
-				} else {
-					// Normal synchronous execution
-					bus.doPublish(handler, topic, event)
-				}
-			} else {
-				bus.wg.Add(1)
-				if handler.transactional {
-					bus.lock.RUnlock()
-					handler.Lock()
-					bus.lock.RLock()
-				}
-				go bus.doPublishAsync(handler, topic, event)
-			}
+			continue
 		}
-	}
 
+		bus.wg.Add(1)
+		if handler.transactional {
+			handler.Lock()
+		}
+		go bus.doPublishAsync(handler, topic, event)
+	}
 	return nil
 }
 
@@ -453,25 +467,34 @@ func (bus *EventBus[T]) doPublishAsync(handler *eventHandler[T], topic string, e
 	bus.doPublish(handler, topic, event)
 }
 
-func (bus *EventBus[T]) removeHandler(topic string, idx int) {
+func (bus *EventBus[T]) removeHandler(topic string, target *eventHandler[T]) bool {
+	bus.lock.Lock()
+	defer bus.lock.Unlock()
+
 	if _, ok := bus.handlers[topic]; !ok {
-		return
-	}
-	l := len(bus.handlers[topic])
-
-	if !(0 <= idx && idx < l) {
-		return
+		return false
 	}
 
-	copy(bus.handlers[topic][idx:], bus.handlers[topic][idx+1:])
-	bus.handlers[topic][l-1] = nil
-	bus.handlers[topic] = bus.handlers[topic][:l-1]
-	bus.metrics.DecrementSubscribers()
+	for idx, handler := range bus.handlers[topic] {
+		if handler != target {
+			continue
+		}
+		l := len(bus.handlers[topic])
+		copy(bus.handlers[topic][idx:], bus.handlers[topic][idx+1:])
+		bus.handlers[topic][l-1] = nil
+		bus.handlers[topic] = bus.handlers[topic][:l-1]
+		if len(bus.handlers[topic]) == 0 {
+			delete(bus.handlers, topic)
+		}
+		bus.metrics.DecrementSubscribers()
 
-	// Log handler removal
-	if bus.logger != nil {
-		bus.logger.Debug("Handler removed from topic '%s'", topic)
+		// Log handler removal
+		if bus.logger != nil {
+			bus.logger.Debug("Handler removed from topic '%s'", topic)
+		}
+		return true
 	}
+	return false
 }
 
 // WaitAsync waits for all async callbacks to complete

--- a/bus_test.go
+++ b/bus_test.go
@@ -296,6 +296,26 @@ func TestMiddleware(t *testing.T) {
 	}
 }
 
+func TestMiddlewareCanSkipHandlers(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	var handlerCalled int32
+
+	bus.AddMiddleware(func(topic string, event interface{}, next func()) error {
+		return nil
+	})
+	bus.SubscribeWithHandle("middleware.skip.test", func(event TestEvent) {
+		atomic.AddInt32(&handlerCalled, 1)
+	})
+
+	bus.Publish("middleware.skip.test", TestEvent{ID: "test", Value: 1})
+
+	if count := atomic.LoadInt32(&handlerCalled); count != 0 {
+		t.Errorf("Expected middleware to skip handler, got %d calls", count)
+	}
+}
+
 func TestPublishWithTimeout(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()
@@ -600,6 +620,31 @@ func TestSubscribeOnce(t *testing.T) {
 	}
 }
 
+func TestMultipleSubscribeOnceSameTopic(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	var first int32
+	var second int32
+
+	bus.SubscribeOnce("once.multi.test", func(event TestEvent) {
+		atomic.AddInt32(&first, 1)
+	})
+	bus.SubscribeOnce("once.multi.test", func(event TestEvent) {
+		atomic.AddInt32(&second, 1)
+	})
+
+	bus.Publish("once.multi.test", TestEvent{ID: "once", Value: 1})
+	bus.Publish("once.multi.test", TestEvent{ID: "again", Value: 2})
+
+	if atomic.LoadInt32(&first) != 1 || atomic.LoadInt32(&second) != 1 {
+		t.Fatalf("Expected both once handlers to run once, got first=%d second=%d", first, second)
+	}
+	if bus.HasCallback("once.multi.test") {
+		t.Error("Expected no callback after once handlers run")
+	}
+}
+
 // TestSubscribeOnceAsync tests one-time asynchronous subscription
 func TestSubscribeOnceAsync(t *testing.T) {
 	bus := NewTyped[TestEvent]()
@@ -708,9 +753,13 @@ func TestGetTopics(t *testing.T) {
 		}
 	}
 
-	// Note: The current implementation doesn't remove empty topic entries from the map
-	// when all handlers are unsubscribed, so topics remain in GetTopics() result
-	// This is the actual behavior of the current implementation
+	handle1.Unsubscribe()
+	handle2.Unsubscribe()
+	handle3.Unsubscribe()
+
+	if topics := bus.GetTopics(); len(topics) != 0 {
+		t.Errorf("Expected no topics after all handlers unsubscribe, got %v", topics)
+	}
 }
 
 // TestGetSubscriberCount tests the GetSubscriberCount function

--- a/handle.go
+++ b/handle.go
@@ -26,25 +26,15 @@ func (h *Handle[T]) Unsubscribe() error {
 		return fmt.Errorf("handle already unsubscribed")
 	}
 
-	h.bus.lock.Lock()
-	defer h.bus.lock.Unlock()
-
-	if handlers, ok := h.bus.handlers[h.topic]; ok {
-		for i, handler := range handlers {
-			if handler == h.handler {
-				// Log unsubscription
-				if h.bus.logger != nil {
-					h.bus.logger.Debug("Unsubscribing handler from topic '%s'", h.topic)
-				}
-				h.bus.removeHandler(h.topic, i)
-				h.handler = nil
-				// Note: removeHandler already calls DecrementSubscribers, so we don't call it again
-				return nil
-			}
-		}
+	if h.bus.logger != nil {
+		h.bus.logger.Debug("Unsubscribing handler from topic '%s'", h.topic)
 	}
+	if !h.bus.removeHandler(h.topic, h.handler) {
+		return fmt.Errorf("handler not found for topic %s", h.topic)
+	}
+	h.handler = nil
 
-	return fmt.Errorf("handler not found for topic %s", h.topic)
+	return nil
 }
 
 // IsActive returns whether this handle is still active

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -13,6 +14,7 @@ import (
 type TestLogger struct {
 	buffer *bytes.Buffer
 	level  LogLevel
+	mu     sync.Mutex
 }
 
 func NewTestLogger() *TestLogger {
@@ -23,6 +25,8 @@ func NewTestLogger() *TestLogger {
 }
 
 func (l *TestLogger) Debug(msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	if l.level <= LogLevelDebug {
 		formatted := fmt.Sprintf(msg, args...)
 		l.buffer.WriteString("[DEBUG] " + formatted + "\n")
@@ -30,6 +34,8 @@ func (l *TestLogger) Debug(msg string, args ...interface{}) {
 }
 
 func (l *TestLogger) Info(msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	if l.level <= LogLevelInfo {
 		formatted := fmt.Sprintf(msg, args...)
 		l.buffer.WriteString("[INFO] " + formatted + "\n")
@@ -37,6 +43,8 @@ func (l *TestLogger) Info(msg string, args ...interface{}) {
 }
 
 func (l *TestLogger) Warn(msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	if l.level <= LogLevelWarn {
 		formatted := fmt.Sprintf(msg, args...)
 		l.buffer.WriteString("[WARN] " + formatted + "\n")
@@ -44,6 +52,8 @@ func (l *TestLogger) Warn(msg string, args ...interface{}) {
 }
 
 func (l *TestLogger) Error(msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	if l.level <= LogLevelError {
 		formatted := fmt.Sprintf(msg, args...)
 		l.buffer.WriteString("[ERROR] " + formatted + "\n")
@@ -51,18 +61,26 @@ func (l *TestLogger) Error(msg string, args ...interface{}) {
 }
 
 func (l *TestLogger) SetLevel(level LogLevel) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.level = level
 }
 
 func (l *TestLogger) GetLevel() LogLevel {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	return l.level
 }
 
 func (l *TestLogger) GetLogs() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	return l.buffer.String()
 }
 
 func (l *TestLogger) Clear() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.buffer.Reset()
 }
 


### PR DESCRIPTION
## Summary
- make middleware next() execute the real handler chain and allow middleware to skip handlers
- remove once handlers by handler reference and clean empty topics
- sync README metric signature and coverage value

## Tests
- GOCACHE=/private/tmp/go-bus-gocache go test ./...
- GOCACHE=/private/tmp/go-bus-gocache go test -race ./...
- GOCACHE=/private/tmp/go-bus-gocache go vet ./...