### PR TITLE
feat: 支持全局通配订阅并加固空输入

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
@@ -26,6 +27,9 @@ type Option[T any] func(*EventBus[T])
 // WithMetrics allows custom Metrics implementation
 func WithMetrics[T any](metrics Metrics) Option[T] {
 	return func(b *EventBus[T]) {
+		if metrics == nil {
+			return
+		}
 		b.metrics = metrics
 	}
 }
@@ -47,6 +51,9 @@ func WithErrorHandler[T any](handler ErrorHandler) Option[T] {
 // WithMiddleware adds a middleware to the EventBus
 func WithMiddleware[T any](middleware EventMiddleware[any]) Option[T] {
 	return func(b *EventBus[T]) {
+		if middleware == nil {
+			return
+		}
 		b.middlewares = append(b.middlewares, middleware)
 	}
 }
@@ -64,7 +71,13 @@ func NewTyped[T any](opts ...Option[T]) Bus[T] {
 		closeCh:     make(chan struct{}),
 	}
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(b)
+	}
+	if b.metrics == nil {
+		b.metrics = &DefaultMetrics{}
 	}
 	return Bus[T](b)
 }
@@ -76,6 +89,14 @@ func New(opts ...Option[any]) Bus[any] {
 
 // doSubscribe handles the subscription logic and is utilized by the public Subscribe functions
 func (bus *EventBus[T]) doSubscribe(topic string, fn func(T), handler *eventHandler[T]) error {
+	if fn == nil {
+		return fmt.Errorf("event handler is nil")
+	}
+	if handler.ctx == nil {
+		handler.ctx = context.Background()
+	}
+	handler.topic = topic
+
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
 
@@ -113,6 +134,14 @@ func (bus *EventBus[T]) doSubscribe(topic string, fn func(T), handler *eventHand
 
 // doSubscribeWithHandle handles the subscription logic and returns a handle
 func (bus *EventBus[T]) doSubscribeWithHandle(topic string, fn func(T), handler *eventHandler[T]) *Handle[T] {
+	if fn == nil {
+		return nil
+	}
+	if handler.ctx == nil {
+		handler.ctx = context.Background()
+	}
+	handler.topic = topic
+
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
 
@@ -296,6 +325,14 @@ func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, ev
 		return fmt.Errorf("event bus is closed")
 	}
 	handlers := append([]*eventHandler[T](nil), bus.handlers[topic]...)
+	if topic != "*" {
+		if wildcardHandlers := bus.handlers["*"]; len(wildcardHandlers) > 0 {
+			handlers = append(handlers, wildcardHandlers...)
+			sort.SliceStable(handlers, func(i, j int) bool {
+				return handlers[i].priority > handlers[j].priority
+			})
+		}
+	}
 	middlewares := append([]EventMiddleware[any](nil), bus.middlewares...)
 	bus.lock.RUnlock()
 
@@ -370,7 +407,7 @@ func (bus *EventBus[T]) publishHandlers(ctx context.Context, topic string, event
 		}
 
 		if handler.flagOnce {
-			bus.removeHandler(topic, handler)
+			bus.removeHandler(handler.topic, handler)
 		}
 
 		if !handler.async {
@@ -523,6 +560,10 @@ func (bus *EventBus[T]) SetErrorHandler(handler ErrorHandler) {
 
 // AddMiddleware adds middleware to the bus
 func (bus *EventBus[T]) AddMiddleware(middleware EventMiddleware[any]) {
+	if middleware == nil {
+		return
+	}
+
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
 	bus.middlewares = append(bus.middlewares, middleware)

--- a/bus_test.go
+++ b/bus_test.go
@@ -732,6 +732,60 @@ func TestMultipleSubscribeOnceSameTopic(t *testing.T) {
 	}
 }
 
+func TestWildcardSubscription(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	var calls []string
+	var mu sync.Mutex
+
+	bus.SubscribeWithPriority("*", func(event TestEvent) {
+		mu.Lock()
+		calls = append(calls, "wildcard:"+event.ID)
+		mu.Unlock()
+	}, PriorityHigh)
+	bus.SubscribeWithHandle("orders.created", func(event TestEvent) {
+		mu.Lock()
+		calls = append(calls, "topic:"+event.ID)
+		mu.Unlock()
+	})
+
+	bus.Publish("orders.created", TestEvent{ID: "a", Value: 1})
+	bus.Publish("users.created", TestEvent{ID: "b", Value: 2})
+
+	want := []string{"wildcard:a", "topic:a", "wildcard:b"}
+	if len(calls) != len(want) {
+		t.Fatalf("Expected %d calls, got %d: %v", len(want), len(calls), calls)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("Expected calls[%d]=%q, got %q", i, want[i], calls[i])
+		}
+	}
+}
+
+func TestWildcardSubscribeOnce(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	var count int32
+	if err := bus.SubscribeOnce("*", func(event TestEvent) {
+		atomic.AddInt32(&count, 1)
+	}); err != nil {
+		t.Fatalf("Unexpected subscribe error: %v", err)
+	}
+
+	bus.Publish("first.topic", TestEvent{ID: "first", Value: 1})
+	bus.Publish("second.topic", TestEvent{ID: "second", Value: 2})
+
+	if atomic.LoadInt32(&count) != 1 {
+		t.Fatalf("Expected wildcard once handler to run once, got %d", count)
+	}
+	if bus.HasCallback("*") {
+		t.Fatal("Expected wildcard once handler to unsubscribe")
+	}
+}
+
 // TestSubscribeOnceAsync tests one-time asynchronous subscription
 func TestSubscribeOnceAsync(t *testing.T) {
 	bus := NewTyped[TestEvent]()
@@ -988,6 +1042,32 @@ func TestClosedBusOperations(t *testing.T) {
 	if handle != nil {
 		t.Error("Expected nil handle when subscribing async to closed bus")
 	}
+}
+
+func TestNilInputsAreIgnoredOrRejected(t *testing.T) {
+	bus := NewTyped[TestEvent](
+		nil,
+		WithMetrics[TestEvent](nil),
+		WithMiddleware[TestEvent](nil),
+	)
+	defer bus.Close()
+
+	if bus.GetMetrics() == nil {
+		t.Fatal("Expected default metrics when nil metrics option is used")
+	}
+
+	bus.AddMiddleware(nil)
+	if err := bus.Subscribe("nil.fn", nil); err == nil {
+		t.Fatal("Expected error for nil handler")
+	}
+	if handle := bus.SubscribeWithHandle("nil.fn", nil); handle != nil {
+		t.Fatal("Expected nil handle for nil handler")
+	}
+	if handle := bus.SubscribeWithContext(nil, "nil.ctx", func(event TestEvent) {}); handle == nil {
+		t.Fatal("Expected nil context to default to background context")
+	}
+
+	bus.Publish("nil.ctx", TestEvent{ID: "ok", Value: 1})
 }
 
 // Helper function to check if string contains substring

--- a/handle.go
+++ b/handle.go
@@ -46,6 +46,7 @@ func (h *Handle[T]) IsActive() bool {
 
 // eventHandler represents an internal event handler
 type eventHandler[T any] struct {
+	topic         string
 	callBack      func(T)
 	flagOnce      bool
 	async         bool


### PR DESCRIPTION
## 变更内容
- 支持 `Subscribe("*", ...)` 全局通配订阅，并保持优先级排序
- 修正通配 once handler 的移除逻辑
- 加固 nil option、nil metrics、nil middleware、nil handler、nil context 的边界行为

## 验证
- `GOCACHE=/private/tmp/go-bus-gocache go test ./...`
- `GOCACHE=/private/tmp/go-bus-gocache go test -race ./...`