### PR TITLE
fix(prometheus): require bus v0.5.0 to resolve an ambiguous import

### DIFF
--- a/prometheus/go.mod
+++ b/prometheus/go.mod
@@ -4,8 +4,15 @@ go 1.21
 
 require (
 	github.com/prometheus/client_golang v1.17.0
-	github.com/townbell/bus v0.4.0
+	// Must be v0.5.0 or newer. Up to and including v0.4.0 the root module still
+	// bundled this package, so an older requirement makes the import path
+	// ambiguous: it would be provided by two modules at once.
+	github.com/townbell/bus v0.5.0
 )
+
+// v0.5.0 required github.com/townbell/bus v0.4.0, which still contains this
+// package, so importing the adapter failed with "ambiguous import".
+retract v0.5.0
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect


### PR DESCRIPTION
`prometheus/v0.5.0` is broken. It shipped with `require github.com/townbell/bus v0.4.0` — the last version in which the root module still bundled this package. Both modules therefore claim the same import path:

```
$ go get github.com/townbell/bus/prometheus
ambiguous import: found package github.com/townbell/bus/prometheus in multiple modules:
	github.com/townbell/bus v0.4.0 (.../bus@v0.4.0/prometheus)
	github.com/townbell/bus/prometheus v0.5.0 (.../bus/prometheus@v0.5.0)
```

Verified directly against the module cache:

| module version | contains `prometheus/*.go`? |
| --- | --- |
| `bus@v0.4.0` | yes — `prometheus.go`, `prometheus_test.go` |
| `bus@v0.5.0` | no — the submodule is excluded from the parent zip |

Requiring `v0.5.0` leaves exactly one module providing the package.

Module versions are immutable once the proxy has fetched them, so `v0.5.0` cannot be corrected in place. It is retracted here and superseded by `v0.5.1`.

**Scope:** only the adapter module is affected. `github.com/townbell/bus@v0.5.0` itself is correct and needs no action — anyone importing just the core library is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)