### PR TITLE
feat!: converge on one Subscribe, error-returning handlers, Publish errors

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,105 @@
+# Migrating from v0.5.x to v0.6.0
+
+[中文版](MIGRATION_ZH.md)
+
+v0.6.0 replaces the subscription API. This is the API that will freeze at
+v1.0.0; v0.6.0 is its trial run, and feedback that surfaces design flaws can
+still change it. There are three changes, and they compose into one mechanical
+rewrite of each subscription site.
+
+## 1. The handler signature is now `func(ctx, T) error`
+
+```go
+// Before
+func(event OrderEvent) { process(event) }
+
+// After
+func(ctx context.Context, event OrderEvent) error {
+    return process(ctx, event)
+}
+```
+
+Why: handlers can now report business failures without panicking, and they can
+observe cancellation. When a handler timeout elapses or the publish context is
+canceled, the handler's `ctx` is canceled — previously the bus could only stop
+*waiting* for a handler; now the handler can actually stop working.
+
+A handler with nothing to report returns `nil`. A returned error is counted in
+metrics as a failed delivery, reported to the `ErrorHandler`, and joined into
+the publish call's return value; it does **not** stop dispatch to the
+remaining handlers.
+
+## 2. One `Subscribe` method replaces all ten variants
+
+Every subscription is now `Subscribe(topic, fn, opts...) (*Handle[T], error)`:
+
+| v0.5.x | v0.6.0 |
+| --- | --- |
+| `Subscribe(topic, fn) error` | `Subscribe(topic, fn)` |
+| `SubscribeWithHandle(topic, fn) *Handle` | `Subscribe(topic, fn)` |
+| `SubscribeAsync(topic, fn, tx) error` | `Subscribe(topic, fn, HandlerAsync(tx))` |
+| `SubscribeAsyncWithHandle(topic, fn, tx) *Handle` | `Subscribe(topic, fn, HandlerAsync(tx))` |
+| `SubscribeOnce(topic, fn) error` | `Subscribe(topic, fn, HandlerOnce())` |
+| `SubscribeOnceAsync(topic, fn) error` | `Subscribe(topic, fn, HandlerOnce(), HandlerAsync(false))` |
+| `SubscribeWithPriority(topic, fn, p) *Handle` | `Subscribe(topic, fn, HandlerPriority(p))` |
+| `SubscribeWithFilter(topic, fn, filter) *Handle` | `Subscribe(topic, fn, HandlerFilter(filter))` |
+| `SubscribeWithContext(ctx, topic, fn) *Handle` | `Subscribe(topic, fn, HandlerContext(ctx))` |
+| `SubscribeWithOptions(topic, fn, opts...) (*Handle, error)` | `Subscribe(topic, fn, opts...)` |
+
+`HandlerFilter` is new; every other option already existed. All options
+compose freely in one call.
+
+The return shape is always `(*Handle[T], error)`. The helpers that used to
+return only a handle failed *silently* — a closed bus or nil callback gave you
+a nil handle and no explanation. Now the reason comes back as an error. If you
+ignore the error, the nil handle is still safe: `Unsubscribe` returns an error
+and `IsActive` returns `false` instead of panicking.
+
+## 3. `Publish` returns an error
+
+```go
+// Before: errors were silently discarded
+bus.Publish("order.created", order)
+
+// After: same call still compiles — the error is ignorable —
+bus.Publish("order.created", order)
+
+// — but now you can also ask what failed:
+if err := bus.Publish("order.created", order); err != nil {
+    log.Printf("delivery failures: %v", err)
+}
+```
+
+The returned error joins the failures of the **synchronous** handlers
+(`errors.Is` works through the join). Asynchronous handler failures are
+reported through the `ErrorHandler` only, because the publish call may return
+before they run.
+
+## Prometheus adapter
+
+The adapter module follows the same version: upgrade both together.
+
+```bash
+go get github.com/townbell/bus@v0.6.0
+go get github.com/townbell/bus/prometheus@v0.6.0
+```
+
+## Mechanical rewrite hints
+
+The handler-body change (`return nil` insertion) resists sed; expect to do
+that part in your editor. The call-site renames are regex-friendly:
+
+```
+SubscribeWithHandle\((.*?)\)            → Subscribe($1)
+SubscribeAsync\((.*?), (true|false)\)   → Subscribe($1, bus.HandlerAsync($2))
+SubscribeOnce\((.*?)\)                  → Subscribe($1, bus.HandlerOnce())
+SubscribeWithPriority\((.*?), (.*?)\)   → Subscribe($1, bus.HandlerPriority($2))
+SubscribeWithFilter\((.*?), (.*?)\)     → Subscribe($1, bus.HandlerFilter($2))
+SubscribeWithOptions\(                  → Subscribe(
+```
+
+`SubscribeWithContext(ctx, topic, fn)` moves its context to the end:
+`Subscribe(topic, fn, bus.HandlerContext(ctx))`.
+
+After rewriting, `go vet ./...` finds any call site the regexes missed — every
+old method name is now an undefined symbol.

--- a/MIGRATION_ZH.md
+++ b/MIGRATION_ZH.md
@@ -1,0 +1,95 @@
+# 从 v0.5.x 迁移到 v0.6.0
+
+[English](MIGRATION.md)
+
+v0.6.0 替换了订阅 API。这套 API 将在 v1.0.0 冻结；v0.6.0 是它的试运行版本，
+如果反馈暴露出设计缺陷仍可能调整。共有三处变更，合起来是对每个订阅点的一次机械性改写。
+
+## 1. handler 签名变为 `func(ctx, T) error`
+
+```go
+// 之前
+func(event OrderEvent) { process(event) }
+
+// 之后
+func(ctx context.Context, event OrderEvent) error {
+    return process(ctx, event)
+}
+```
+
+原因：handler 现在可以不通过 panic 上报业务失败，并且能感知取消。当 handler 超时
+或发布方的 context 被取消时，handler 收到的 `ctx` 会被取消——以前总线只能放弃
+*等待* handler，现在 handler 自己可以真正停下来。
+
+无需上报时返回 `nil`。返回的错误会计入失败指标、上报给 `ErrorHandler`，并合并进
+发布调用的返回值；它**不会**中断对后续 handler 的派发。
+
+## 2. 一个 `Subscribe` 取代全部十个变体
+
+所有订阅统一为 `Subscribe(topic, fn, opts...) (*Handle[T], error)`：
+
+| v0.5.x | v0.6.0 |
+| --- | --- |
+| `Subscribe(topic, fn) error` | `Subscribe(topic, fn)` |
+| `SubscribeWithHandle(topic, fn) *Handle` | `Subscribe(topic, fn)` |
+| `SubscribeAsync(topic, fn, tx) error` | `Subscribe(topic, fn, HandlerAsync(tx))` |
+| `SubscribeAsyncWithHandle(topic, fn, tx) *Handle` | `Subscribe(topic, fn, HandlerAsync(tx))` |
+| `SubscribeOnce(topic, fn) error` | `Subscribe(topic, fn, HandlerOnce())` |
+| `SubscribeOnceAsync(topic, fn) error` | `Subscribe(topic, fn, HandlerOnce(), HandlerAsync(false))` |
+| `SubscribeWithPriority(topic, fn, p) *Handle` | `Subscribe(topic, fn, HandlerPriority(p))` |
+| `SubscribeWithFilter(topic, fn, filter) *Handle` | `Subscribe(topic, fn, HandlerFilter(filter))` |
+| `SubscribeWithContext(ctx, topic, fn) *Handle` | `Subscribe(topic, fn, HandlerContext(ctx))` |
+| `SubscribeWithOptions(topic, fn, opts...) (*Handle, error)` | `Subscribe(topic, fn, opts...)` |
+
+`HandlerFilter` 是新增选项；其余选项此前已存在，全部选项可在一次调用中自由组合。
+
+返回形状统一为 `(*Handle[T], error)`。过去只返回 handle 的方法是*静默*失败的——
+总线已关闭或回调为 nil 时你只拿到 nil handle，不知道原因；现在原因通过 error 返回。
+即使忽略 error，nil handle 依然安全：`Unsubscribe` 返回错误、`IsActive` 返回
+`false`，不会 panic。
+
+## 3. `Publish` 返回 error
+
+```go
+// 之前：错误被静默丢弃
+bus.Publish("order.created", order)
+
+// 之后：同样的写法依旧编译通过——错误可以忽略——
+bus.Publish("order.created", order)
+
+// ——但现在也可以知道哪里失败了：
+if err := bus.Publish("order.created", order); err != nil {
+    log.Printf("投递失败: %v", err)
+}
+```
+
+返回的错误合并了**同步** handler 的全部失败（`errors.Is` 可以穿透合并后的错误）。
+异步 handler 的失败只通过 `ErrorHandler` 上报，因为发布调用可能在它们运行前就已返回。
+
+## Prometheus 适配器
+
+适配器模块跟随同一版本号，请一起升级：
+
+```bash
+go get github.com/townbell/bus@v0.6.0
+go get github.com/townbell/bus/prometheus@v0.6.0
+```
+
+## 机械性改写提示
+
+handler 函数体的改动（补 `return nil`）不适合 sed，建议在编辑器里完成。
+调用点的改名是正则友好的：
+
+```
+SubscribeWithHandle\((.*?)\)            → Subscribe($1)
+SubscribeAsync\((.*?), (true|false)\)   → Subscribe($1, bus.HandlerAsync($2))
+SubscribeOnce\((.*?)\)                  → Subscribe($1, bus.HandlerOnce())
+SubscribeWithPriority\((.*?), (.*?)\)   → Subscribe($1, bus.HandlerPriority($2))
+SubscribeWithFilter\((.*?), (.*?)\)     → Subscribe($1, bus.HandlerFilter($2))
+SubscribeWithOptions\(                  → Subscribe(
+```
+
+`SubscribeWithContext(ctx, topic, fn)` 的 context 移到末尾：
+`Subscribe(topic, fn, bus.HandlerContext(ctx))`。
+
+改写完成后，`go vet ./...` 会找出正则漏掉的调用点——所有旧方法名现在都是未定义符号。

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ import "github.com/townbell/bus" // package bus
 
 [中文文档](README_ZH.md)
 
+> **v0.6.0 replaced the subscription API.** One `Subscribe` method with
+> options, handlers of the form `func(ctx, T) error`, and `Publish` returns an
+> error. Coming from v0.5.x? See [MIGRATION.md](MIGRATION.md) — the rewrite is
+> mechanical. This API freezes at v1.0.0; design feedback is welcome now.
+
 ## ✨ Features
 
 ### 🔧 Core Features
@@ -68,7 +73,9 @@ go get github.com/townbell/bus/prometheus
 package main
 
 import (
+    "context"
     "fmt"
+
     "github.com/townbell/bus"
 )
 
@@ -83,12 +90,17 @@ func main() {
     defer eventBus.Close()
 
     // Subscribe to events
-    handle := eventBus.SubscribeWithHandle("user.login", func(event UserEvent) {
+    handle, err := eventBus.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
         fmt.Printf("User %s performed %s\n", event.UserID, event.Action)
+        return nil
     })
+    if err != nil {
+        panic(err)
+    }
     defer handle.Unsubscribe()
 
-    // Publish events
+    // Publish events. The returned error joins any synchronous handler
+    // failures and is safe to ignore when they do not matter to the caller.
     eventBus.Publish("user.login", UserEvent{
         UserID: "user123",
         Action: "login",
@@ -104,19 +116,22 @@ Handlers with different priorities execute in priority order:
 
 ```go
 // High priority - security checks
-securityHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+securityHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Println("🔒 Security check")
-}, bus.PriorityCritical)
+    return nil
+}, bus.HandlerPriority(bus.PriorityCritical))
 
 // Normal priority - business logic
-businessHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+businessHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Println("📋 Business processing")
-}, bus.PriorityNormal)
+    return nil
+}, bus.HandlerPriority(bus.PriorityNormal))
 
 // Low priority - analytics
-analyticsHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+analyticsHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Println("📊 Analytics")
-}, bus.PriorityLow)
+    return nil
+}, bus.HandlerPriority(bus.PriorityLow))
 ```
 
 ### Event Filtering
@@ -125,16 +140,18 @@ Process only events that match specific criteria:
 
 ```go
 // Only process admin user events
-adminHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEvent) {
+adminHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Printf("Admin action: %s\n", event.UserID)
-}, func(topic string, event UserEvent) bool {
+    return nil
+}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
     return strings.HasPrefix(event.UserID, "admin_")
-})
+}))
 
 // Only process sensitive operations
-sensitiveHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEvent) {
+sensitiveHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Printf("Sensitive operation alert: %s\n", event.Action)
-}, func(topic string, event UserEvent) bool {
+    return nil
+}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
     sensitiveActions := []string{"delete", "modify_permissions"}
     for _, action := range sensitiveActions {
         if event.Action == action {
@@ -142,7 +159,7 @@ sensitiveHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEv
         }
     }
     return false
-})
+}))
 ```
 
 ### Context Control
@@ -150,16 +167,18 @@ sensitiveHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEv
 Use context for cancellation and timeout control:
 
 ```go
-// Context cancellation
+// Context cancellation: canceling the subscription context disables the handler
 ctx, cancel := context.WithCancel(context.Background())
-handle := eventBus.SubscribeWithContext(ctx, "user.session", func(event UserEvent) {
+handle, _ := eventBus.Subscribe("user.session", func(ctx context.Context, event UserEvent) error {
     fmt.Printf("Session event: %s\n", event.UserID)
-})
+    return nil
+}, bus.HandlerContext(ctx))
 
 // Cancel subscription
 cancel()
 
-// Timeout publishing
+// Timeout publishing. The handler's ctx is canceled when the deadline passes,
+// so a cooperative handler can stop early instead of running to completion.
 err := eventBus.PublishWithTimeout("user.action", event, 5*time.Second)
 if err != nil {
     fmt.Printf("Publish timeout: %v\n", err)
@@ -168,7 +187,25 @@ if err != nil {
 
 ### Error Handling
 
-Set up global error handler:
+Handlers report business failures by returning an error. The failure is
+counted in metrics, reported to the global `ErrorHandler`, and joined into the
+publish call's return value — dispatch to the remaining handlers continues:
+
+```go
+eventBus.Subscribe("order.created", func(ctx context.Context, event OrderEvent) error {
+    if err := reserveStock(ctx, event); err != nil {
+        return fmt.Errorf("reserve stock: %w", err)
+    }
+    return nil
+})
+
+if err := eventBus.Publish("order.created", order); err != nil {
+    log.Printf("delivery failures: %v", err) // errors.Is sees through the join
+}
+```
+
+Set up a global error handler to observe every failure, including those from
+asynchronous handlers (whose errors never reach the publish return value):
 
 ```go
 eventBus.SetErrorHandler(func(err *bus.EventError) {
@@ -246,41 +283,48 @@ eventBus := bus.NewTyped[UserEvent](
 
 ```go
 // Async processing, non-transactional (concurrent execution)
-err := eventBus.SubscribeAsync("user.notification", func(event UserEvent) {
-    sendEmail(event.UserID)
-}, false)
+_, err := eventBus.Subscribe("user.notification", func(ctx context.Context, event UserEvent) error {
+    return sendEmail(ctx, event.UserID)
+}, bus.HandlerAsync(false))
 
 // Async processing, transactional (serial execution)
-err := eventBus.SubscribeAsync("user.audit", func(event UserEvent) {
-    writeAuditLog(event)
-}, true)
+_, err = eventBus.Subscribe("user.audit", func(ctx context.Context, event UserEvent) error {
+    return writeAuditLog(ctx, event)
+}, bus.HandlerAsync(true))
 ```
 
 ### Handler Execution Control
 
-`SubscribeWithOptions` adds handler-level controls without changing the existing simple APIs:
+Every subscription concern is a `HandlerOption`, and they compose freely in
+one `Subscribe` call:
 
 ```go
-handle, err := eventBus.SubscribeWithOptions("payment.validate", func(event PaymentEvent) {
-    validatePayment(event)
-},
-    bus.HandlerTimeout(2*time.Second),
-    bus.HandlerRecoverPolicy(bus.RecoverAndStop),
-    bus.HandlerSerial(),
+handle, err := eventBus.Subscribe("payment.validate",
+    func(ctx context.Context, event PaymentEvent) error {
+        return validatePayment(ctx, event)
+    },
+    bus.HandlerTimeout(2*time.Second),           // cancels ctx when it elapses
+    bus.HandlerRecoverPolicy(bus.RecoverAndStop), // a panic aborts the publish
+    bus.HandlerSerial(),                          // one execution at a time
     bus.HandlerPriority(bus.PriorityHigh),
 )
 ```
 
+Available options: `HandlerPriority`, `HandlerFilter`, `HandlerContext`,
+`HandlerAsync`, `HandlerOnce`, `HandlerTimeout`, `HandlerRecoverPolicy`,
+`HandlerMaxConcurrency`, `HandlerSerial`.
+
 ## ✅ Behavior Contract
 
-- `Publish` ignores returned errors; use `PublishWithContext` or `PublishWithTimeout` when cancellation, timeout, or closed-bus errors matter.
-- Synchronous handlers run in the current goroutine by default; asynchronous handlers run in separate goroutines, and `transactional=true` serializes calls to the same handler.
-- Handler timeouts bound how long the publish call waits; they do not forcibly stop a handler that has already started running.
-- Handler panics are recovered by default, failed metrics are incremented, and the error is reported through `ErrorHandler`; `RecoverAndStop` makes a recovered panic stop the current publish call.
+- `Publish` and `PublishWithContext` return the joined failures of the synchronous handlers (`errors.Is` sees through the join). The error is safe to ignore. Asynchronous handler failures are reported through `ErrorHandler` only, because the publish call may return before they run.
+- A handler error does not stop dispatch: the remaining handlers still run. Dispatch stops early only when the publish context is canceled, the bus closes, or a handler panics under `RecoverAndStop`.
+- Synchronous handlers run in the goroutine that calls publish and receive a context derived from the publish call; asynchronous handlers run in separate goroutines and receive the subscription context (`HandlerContext`), and `HandlerAsync(true)` serializes calls to the same handler.
+- `HandlerTimeout` bounds how long the publish call waits and cancels the handler's context when it elapses; a handler that ignores its context keeps running in the background and is still awaited by `WaitAsync` and `Close`.
+- Handler panics are recovered, counted as failures, and reported through `ErrorHandler`; `RecoverAndContinue` (the default) keeps dispatching, `RecoverAndStop` aborts the publish call. Either way the recovered panic appears in the publish error.
 - Middleware must call `next()` to continue to the next middleware and handlers; skipping `next()` intercepts the event.
-- `SubscribeOnce` / `SubscribeOnceAsync` handlers execute successfully at most once, including when multiple one-time handlers share a topic.
+- `HandlerOnce` handlers execute successfully at most once, including when multiple one-time handlers share a topic.
 - After `Close`, the bus rejects new publish and subscribe calls; already-started async handlers are allowed to finish.
-- Subscribe helpers that return only a `*Handle[T]` yield `nil` when the subscription is rejected (nil callback, or a closed bus). A `nil` handle is safe to use: `Unsubscribe` returns an error and `IsActive` returns `false`, so a deferred `Unsubscribe` never panics. Use `SubscribeWithOptions` when you want the rejection reason.
+- `Subscribe` returns `(nil, error)` when the subscription is rejected (nil callback, mismatched filter type, or a closed bus). A `nil` handle is safe to use: `Unsubscribe` returns an error and `IsActive` returns `false`, so ignoring the error and deferring `Unsubscribe` never panics.
 
 ## 🗺️ RoadMap
 
@@ -296,9 +340,9 @@ Townbell will keep its focus on being an in-process, type-safe, lightweight even
 | P1 | Done | Continuous integration | GitHub Actions runs build, vet, race tests, a gofmt gate and a coverage floor across a Go version matrix, and vets `example/` explicitly |
 | P1 | Done | Dependency-free core | The Prometheus adapter moved into its own module, so importing `bus` pulls in nothing but the standard library |
 | P1 | Done | Runnable documentation | Godoc `Example` functions execute in CI with verified output and render on pkg.go.dev |
-| P0 | Planned | Subscription API convergence | Three different shapes coexist today: `error` only, `*Handle[T]` only, and `(*Handle[T], error)`. Converge on the last one. Breaking, so it gates v1.0.0 |
-| P0 | Planned | Handler error reporting | Handlers are `func(T)` and cannot report a business failure except by panicking, so `ErrorHandler` only ever sees panics and timeouts. Breaking, gates v1.0.0, and unblocks result collection |
-| P0 | Planned | `Publish` error semantics | Decide whether `Publish` returns an error or whether discarding it becomes a permanent contract. Gates v1.0.0 |
+| P0 | Preview (v0.6.0) | Subscription API convergence | One `Subscribe(topic, fn, opts...) (*Handle[T], error)` replaced the ten previous variants. Freezes at v1.0.0 |
+| P0 | Preview (v0.6.0) | Handler error reporting | Handlers are `func(ctx, T) error`: business failures reach metrics, the `ErrorHandler`, and the publish return value without panicking. Unblocks result collection. Freezes at v1.0.0 |
+| P0 | Preview (v0.6.0) | `Publish` error semantics | `Publish` returns the joined synchronous-handler failures; ignoring it stays legal. Freezes at v1.0.0 |
 | P2 | Planned | Result collection | Borrow from Blinker and add a `PublishCollect`-style API for collecting handler results or errors |
 | P2 | Partial | Topic enhancements | Wildcard (`*`) topics are implemented; hierarchical topics and no-subscriber hooks are still planned |
 | P2 | Planned | Integration examples | Add practical examples for `net/http`, Gin, CLI apps, and workers |
@@ -323,16 +367,12 @@ The library is organized into separate modules for better maintainability:
 ```go
 // Subscriber interface
 type BusSubscriber[T any] interface {
-    Subscribe(topic string, fn func(T)) error
-    SubscribeWithPriority(topic string, fn func(T), priority Priority) *Handle[T]
-    SubscribeWithFilter(topic string, fn func(T), filter EventFilter[T]) *Handle[T]
-    SubscribeWithContext(ctx context.Context, topic string, fn func(T)) *Handle[T]
-    // ...
+    Subscribe(topic string, fn Handler[T], options ...HandlerOption) (*Handle[T], error)
 }
 
 // Publisher interface
 type BusPublisher[T any] interface {
-    Publish(topic string, event T)
+    Publish(topic string, event T) error
     PublishWithContext(ctx context.Context, topic string, event T) error
     PublishWithTimeout(topic string, event T, timeout time.Duration) error
 }
@@ -350,6 +390,9 @@ type BusController interface {
 ### Type System
 
 ```go
+// Event handler
+type Handler[T any] func(ctx context.Context, event T) error
+
 // Event filter
 type EventFilter[T any] func(topic string, event T) bool
 
@@ -437,21 +480,20 @@ eventBus.SetErrorHandler(func(err *EventError) {
 
 ```go
 // Use async for non-critical paths
-eventBus.SubscribeAsync("analytics.track", func(event UserEvent) {
-    // Non-critical analytics
-    analytics.Track(event)
-}, false)
+eventBus.Subscribe("analytics.track", func(ctx context.Context, event UserEvent) error {
+    return analytics.Track(ctx, event) // Non-critical analytics
+}, bus.HandlerAsync(false))
 
 // Use sync for critical paths
-eventBus.Subscribe("payment.validate", func(event PaymentEvent) {
-    // Critical payment validation
-    validatePayment(event)
+eventBus.Subscribe("payment.validate", func(ctx context.Context, event PaymentEvent) error {
+    return validatePayment(ctx, event) // Critical payment validation
 })
 
 // Use filters to reduce unnecessary processing
-eventBus.SubscribeWithFilter("user.activity", handler, func(topic string, event UserEvent) bool {
-    return event.IsImportant() // Only process important events
-})
+eventBus.Subscribe("user.activity", handler, bus.HandlerFilter(
+    func(topic string, event UserEvent) bool {
+        return event.IsImportant() // Only process important events
+    }))
 ```
 
 ## 🔍 Comparison with Other Libraries

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -24,6 +24,11 @@ import "github.com/townbell/bus" // 包名为 bus
 
 [English Documentation](README.md)
 
+> **v0.6.0 替换了订阅 API。** 一个带选项的 `Subscribe`、形如 `func(ctx, T) error`
+> 的 handler、返回 error 的 `Publish`。从 v0.5.x 升级请看
+> [MIGRATION_ZH.md](MIGRATION_ZH.md)——改写是机械性的。这套 API 将在 v1.0.0
+> 冻结，现在正是提设计反馈的时候。
+
 ## ✨ 特性
 
 ### 🔧 核心功能
@@ -67,7 +72,9 @@ go get github.com/townbell/bus/prometheus
 package main
 
 import (
+    "context"
     "fmt"
+
     "github.com/townbell/bus"
 )
 
@@ -82,12 +89,16 @@ func main() {
     defer eventBus.Close()
 
     // 订阅事件
-    handle := eventBus.SubscribeWithHandle("user.login", func(event UserEvent) {
+    handle, err := eventBus.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
         fmt.Printf("用户 %s 执行了 %s\n", event.UserID, event.Action)
+        return nil
     })
+    if err != nil {
+        panic(err)
+    }
     defer handle.Unsubscribe()
 
-    // 发布事件
+    // 发布事件。返回值合并了同步 handler 的失败，不关心时可以直接忽略。
     eventBus.Publish("user.login", UserEvent{
         UserID: "user123",
         Action: "login",
@@ -103,19 +114,22 @@ func main() {
 
 ```go
 // 高优先级 - 安全检查
-securityHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+securityHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Println("🔒 安全检查")
-}, bus.PriorityCritical)
+    return nil
+}, bus.HandlerPriority(bus.PriorityCritical))
 
 // 普通优先级 - 业务逻辑
-businessHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+businessHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Println("📋 业务处理")
-}, bus.PriorityNormal)
+    return nil
+}, bus.HandlerPriority(bus.PriorityNormal))
 
 // 低优先级 - 统计分析
-analyticsHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+analyticsHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Println("📊 数据统计")
-}, bus.PriorityLow)
+    return nil
+}, bus.HandlerPriority(bus.PriorityLow))
 ```
 
 ### 事件过滤
@@ -124,16 +138,18 @@ analyticsHandle := eventBus.SubscribeWithPriority("user.action", func(event User
 
 ```go
 // 只处理管理员用户的事件
-adminHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEvent) {
+adminHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Printf("管理员操作: %s\n", event.UserID)
-}, func(topic string, event UserEvent) bool {
+    return nil
+}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
     return strings.HasPrefix(event.UserID, "admin_")
-})
+}))
 
 // 只处理敏感操作
-sensitiveHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEvent) {
+sensitiveHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
     fmt.Printf("敏感操作告警: %s\n", event.Action)
-}, func(topic string, event UserEvent) bool {
+    return nil
+}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
     sensitiveActions := []string{"delete", "modify_permissions"}
     for _, action := range sensitiveActions {
         if event.Action == action {
@@ -141,7 +157,7 @@ sensitiveHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEv
         }
     }
     return false
-})
+}))
 ```
 
 ### 上下文控制
@@ -149,16 +165,18 @@ sensitiveHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEv
 使用 context 进行取消和超时控制：
 
 ```go
-// 上下文取消
+// 上下文取消：取消订阅 context 会停用该 handler
 ctx, cancel := context.WithCancel(context.Background())
-handle := eventBus.SubscribeWithContext(ctx, "user.session", func(event UserEvent) {
+handle, _ := eventBus.Subscribe("user.session", func(ctx context.Context, event UserEvent) error {
     fmt.Printf("会话事件: %s\n", event.UserID)
-})
+    return nil
+}, bus.HandlerContext(ctx))
 
 // 取消订阅
 cancel()
 
-// 超时发布
+// 超时发布。截止时间一到，handler 的 ctx 会被取消，
+// 配合的 handler 可以提前停止，而不是继续跑完。
 err := eventBus.PublishWithTimeout("user.action", event, 5*time.Second)
 if err != nil {
     fmt.Printf("发布超时: %v\n", err)
@@ -167,7 +185,24 @@ if err != nil {
 
 ### 错误处理
 
-设置全局错误处理器：
+handler 通过返回 error 上报业务失败。失败会计入指标、上报给全局 `ErrorHandler`，
+并合并进发布调用的返回值——对后续 handler 的派发继续进行：
+
+```go
+eventBus.Subscribe("order.created", func(ctx context.Context, event OrderEvent) error {
+    if err := reserveStock(ctx, event); err != nil {
+        return fmt.Errorf("预留库存: %w", err)
+    }
+    return nil
+})
+
+if err := eventBus.Publish("order.created", order); err != nil {
+    log.Printf("投递失败: %v", err) // errors.Is 可以穿透合并后的错误
+}
+```
+
+设置全局错误处理器可以观察到全部失败，包括异步 handler 的
+（它们的错误不会出现在发布调用的返回值里）：
 
 ```go
 eventBus.SetErrorHandler(func(err *bus.EventError) {
@@ -245,41 +280,47 @@ eventBus := bus.NewTyped[UserEvent](
 
 ```go
 // 异步处理，非事务性（并发执行）
-err := eventBus.SubscribeAsync("user.notification", func(event UserEvent) {
-    sendEmail(event.UserID)
-}, false)
+_, err := eventBus.Subscribe("user.notification", func(ctx context.Context, event UserEvent) error {
+    return sendEmail(ctx, event.UserID)
+}, bus.HandlerAsync(false))
 
 // 异步处理，事务性（串行执行）
-err := eventBus.SubscribeAsync("user.audit", func(event UserEvent) {
-    writeAuditLog(event)
-}, true)
+_, err = eventBus.Subscribe("user.audit", func(ctx context.Context, event UserEvent) error {
+    return writeAuditLog(ctx, event)
+}, bus.HandlerAsync(true))
 ```
 
 ### Handler 执行控制
 
-`SubscribeWithOptions` 可以为单个 handler 设置 timeout、recover 策略和并发控制：
+所有订阅关注点都是 `HandlerOption`，可以在一次 `Subscribe` 调用中自由组合：
 
 ```go
-handle, err := eventBus.SubscribeWithOptions("payment.validate", func(event PaymentEvent) {
-    validatePayment(event)
-},
-    bus.HandlerTimeout(2*time.Second),
-    bus.HandlerRecoverPolicy(bus.RecoverAndStop),
-    bus.HandlerSerial(),
+handle, err := eventBus.Subscribe("payment.validate",
+    func(ctx context.Context, event PaymentEvent) error {
+        return validatePayment(ctx, event)
+    },
+    bus.HandlerTimeout(2*time.Second),            // 超时到达时取消 ctx
+    bus.HandlerRecoverPolicy(bus.RecoverAndStop), // panic 中止本次发布
+    bus.HandlerSerial(),                          // 同一时间只执行一个
     bus.HandlerPriority(bus.PriorityHigh),
 )
 ```
 
+可用选项：`HandlerPriority`、`HandlerFilter`、`HandlerContext`、`HandlerAsync`、
+`HandlerOnce`、`HandlerTimeout`、`HandlerRecoverPolicy`、`HandlerMaxConcurrency`、
+`HandlerSerial`。
+
 ## ✅ 行为约定
 
-- `Publish` 会忽略返回错误；需要感知取消、超时或关闭错误时，请使用 `PublishWithContext` 或 `PublishWithTimeout`。
-- 同步 handler 默认在当前 goroutine 执行；异步 handler 会在独立 goroutine 执行，`transactional=true` 时同一 handler 串行执行。
-- handler timeout 限制的是发布调用等待时间，不会强制终止已经开始运行的 handler。
-- handler panic 默认会被恢复，失败计数会增加，并通过 `ErrorHandler` 上报；`RecoverAndStop` 会让已恢复的 panic 停止当前发布流程。
+- `Publish` 和 `PublishWithContext` 返回同步 handler 的失败合并（`errors.Is` 可以穿透）。这个错误可以安全忽略。异步 handler 的失败只通过 `ErrorHandler` 上报，因为发布调用可能在它们运行前就已返回。
+- handler 返回错误不会中断派发：后续 handler 照常执行。只有发布 context 被取消、总线关闭、或 handler 在 `RecoverAndStop` 策略下 panic 时才会提前终止派发。
+- 同步 handler 在调用发布的 goroutine 中执行，收到从发布调用派生的 context；异步 handler 在独立 goroutine 中执行，收到订阅 context（`HandlerContext`），`HandlerAsync(true)` 时同一 handler 串行执行。
+- `HandlerTimeout` 限制发布调用的等待时间，并在超时到达时取消 handler 的 context；无视 context 的 handler 会继续在后台运行，仍会被 `WaitAsync` 和 `Close` 等待。
+- handler panic 会被恢复、计入失败并通过 `ErrorHandler` 上报；`RecoverAndContinue`（默认）继续派发，`RecoverAndStop` 中止本次发布。两种情况下恢复的 panic 都会出现在发布错误里。
 - middleware 必须调用 `next()` 才会继续执行后续 middleware 和 handler；不调用 `next()` 可用于拦截事件。
-- `SubscribeOnce` / `SubscribeOnceAsync` 的 handler 只会成功执行一次，即使同一 topic 下有多个一次性 handler。
+- `HandlerOnce` 的 handler 只会成功执行一次，即使同一 topic 下有多个一次性 handler。
 - `Close` 后不再接受新发布或订阅；已启动的异步 handler 会在关闭流程中等待完成。
-- 只返回 `*Handle[T]` 的订阅方法在订阅被拒绝时（callback 为 nil，或 bus 已关闭）会返回 `nil`。`nil` handle 可以安全使用：`Unsubscribe` 返回错误、`IsActive` 返回 `false`，因此 `defer handle.Unsubscribe()` 不会 panic。需要知道拒绝原因时请用 `SubscribeWithOptions`。
+- 订阅被拒绝时（callback 为 nil、filter 类型不匹配、或总线已关闭），`Subscribe` 返回 `(nil, error)`。`nil` handle 可以安全使用：`Unsubscribe` 返回错误、`IsActive` 返回 `false`，因此忽略错误后 `defer handle.Unsubscribe()` 也不会 panic。
 
 ## 🗺️ RoadMap
 
@@ -295,9 +336,9 @@ Townbell 会优先保持“进程内、类型安全、轻量事件总线”的�
 | P1 | 已完成 | 持续集成 | GitHub Actions 在 Go 版本矩阵上执行 build、vet、race 测试、gofmt 门禁和覆盖率下限，并显式 vet `example/` |
 | P1 | 已完成 | 核心零依赖 | Prometheus 适配器拆为独立模块，引入 `bus` 只会带进标准库 |
 | P1 | 已完成 | 可执行文档 | godoc `Example` 函数在 CI 中带输出校验执行，并展示在 pkg.go.dev 上 |
-| P0 | 未完成 | 订阅 API 收敛 | 目前并存三种签名：只返回 `error`、只返回 `*Handle[T]`、返回 `(*Handle[T], error)`。应统一到最后一种。属破坏性变更，是 v1.0.0 的前置条件 |
-| P0 | 未完成 | handler 错误上报 | handler 是 `func(T)`，业务失败除了 panic 无法上报，导致 `ErrorHandler` 实际只能收到 panic 和 timeout。属破坏性变更，是 v1.0.0 的前置条件，同时解锁返回值收集 |
-| P0 | 未完成 | `Publish` 错误语义 | 定案 `Publish` 是返回 error，还是把"丢弃错误"确立为永久契约。v1.0.0 的前置条件 |
+| P0 | 试运行（v0.6.0） | 订阅 API 收敛 | 一个 `Subscribe(topic, fn, opts...) (*Handle[T], error)` 取代了此前的十个变体。将在 v1.0.0 冻结 |
+| P0 | 试运行（v0.6.0） | handler 错误上报 | handler 变为 `func(ctx, T) error`：业务失败无需 panic 即可进入指标、`ErrorHandler` 和发布返回值。解锁返回值收集。将在 v1.0.0 冻结 |
+| P0 | 试运行（v0.6.0） | `Publish` 错误语义 | `Publish` 返回同步 handler 失败的合并；忽略它依然合法。将在 v1.0.0 冻结 |
 | P2 | 未完成 | 返回值收集 | 参考 Blinker，提供 `PublishCollect` 一类 API，收集多个 handler 的返回值或错误 |
 | P2 | 部分完成 | Topic 增强 | 通配符（`*`）topic 已实现；层级 topic、无订阅者事件 hook 仍待开发 |
 | P2 | 未完成 | 集成示例 | 补充 `net/http`、Gin、CLI、worker 等实际项目中的使用方式 |
@@ -322,16 +363,12 @@ Townbell 会优先保持“进程内、类型安全、轻量事件总线”的�
 ```go
 // 订阅者接口
 type BusSubscriber[T any] interface {
-    Subscribe(topic string, fn func(T)) error
-    SubscribeWithPriority(topic string, fn func(T), priority Priority) *Handle[T]
-    SubscribeWithFilter(topic string, fn func(T), filter EventFilter[T]) *Handle[T]
-    SubscribeWithContext(ctx context.Context, topic string, fn func(T)) *Handle[T]
-    // ...
+    Subscribe(topic string, fn Handler[T], options ...HandlerOption) (*Handle[T], error)
 }
 
 // 发布者接口
 type BusPublisher[T any] interface {
-    Publish(topic string, event T)
+    Publish(topic string, event T) error
     PublishWithContext(ctx context.Context, topic string, event T) error
     PublishWithTimeout(topic string, event T, timeout time.Duration) error
 }
@@ -349,6 +386,9 @@ type BusController interface {
 ### 类型系统
 
 ```go
+// 事件处理器
+type Handler[T any] func(ctx context.Context, event T) error
+
 // 事件过滤器
 type EventFilter[T any] func(topic string, event T) bool
 
@@ -436,21 +476,20 @@ eventBus.SetErrorHandler(func(err *EventError) {
 
 ```go
 // 使用异步处理非关键路径
-eventBus.SubscribeAsync("analytics.track", func(event UserEvent) {
-    // 非关键的数据统计
-    analytics.Track(event)
-}, false)
+eventBus.Subscribe("analytics.track", func(ctx context.Context, event UserEvent) error {
+    return analytics.Track(ctx, event) // 非关键的数据统计
+}, bus.HandlerAsync(false))
 
 // 关键路径使用同步处理
-eventBus.Subscribe("payment.validate", func(event PaymentEvent) {
-    // 关键的支付验证
-    validatePayment(event)
+eventBus.Subscribe("payment.validate", func(ctx context.Context, event PaymentEvent) error {
+    return validatePayment(ctx, event) // 关键的支付验证
 })
 
 // 使用过滤器减少不必要的处理
-eventBus.SubscribeWithFilter("user.activity", handler, func(topic string, event UserEvent) bool {
-    return event.IsImportant() // 只处理重要事件
-})
+eventBus.Subscribe("user.activity", handler, bus.HandlerFilter(
+    func(topic string, event UserEvent) bool {
+        return event.IsImportant() // 只处理重要事件
+    }))
 ```
 
 ## 🔍 与其他库的对比

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
 package bus
 
 import (
+	"context"
 	"sync"
 	"testing"
 )
@@ -10,14 +11,17 @@ type BenchEvent struct {
 	Data string
 }
 
+func benchHandler(ctx context.Context, event BenchEvent) error {
+	// Simple processing
+	_ = event.ID * 2
+	return nil
+}
+
 func BenchmarkSyncPublish(b *testing.B) {
 	bus := NewTyped[BenchEvent]()
 	defer bus.Close()
 
-	bus.SubscribeWithHandle("bench.sync", func(event BenchEvent) {
-		// Simple processing
-		_ = event.ID * 2
-	})
+	mustSubscribe(b, bus, "bench.sync", benchHandler)
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -36,10 +40,7 @@ func BenchmarkAsyncPublish(b *testing.B) {
 	bus := NewTyped[BenchEvent]()
 	defer bus.Close()
 
-	bus.SubscribeAsync("bench.async", func(event BenchEvent) {
-		// Simple processing
-		_ = event.ID * 2
-	}, false)
+	mustSubscribe(b, bus, "bench.async", benchHandler, HandlerAsync(false))
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -63,9 +64,7 @@ func BenchmarkMultipleSubscribers(b *testing.B) {
 	// Create multiple subscribers
 	numSubscribers := 10
 	for i := 0; i < numSubscribers; i++ {
-		bus.SubscribeWithHandle("bench.multi", func(event BenchEvent) {
-			_ = event.ID * 2
-		})
+		mustSubscribe(b, bus, "bench.multi", benchHandler)
 	}
 
 	b.ResetTimer()
@@ -86,17 +85,9 @@ func BenchmarkWithPriority(b *testing.B) {
 	defer bus.Close()
 
 	// Subscribers with different priorities
-	bus.SubscribeWithPriority("bench.priority", func(event BenchEvent) {
-		_ = event.ID * 2
-	}, PriorityCritical)
-
-	bus.SubscribeWithPriority("bench.priority", func(event BenchEvent) {
-		_ = event.ID * 3
-	}, PriorityNormal)
-
-	bus.SubscribeWithPriority("bench.priority", func(event BenchEvent) {
-		_ = event.ID * 4
-	}, PriorityLow)
+	mustSubscribe(b, bus, "bench.priority", benchHandler, HandlerPriority(PriorityCritical))
+	mustSubscribe(b, bus, "bench.priority", benchHandler, HandlerPriority(PriorityNormal))
+	mustSubscribe(b, bus, "bench.priority", benchHandler, HandlerPriority(PriorityLow))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -112,11 +103,10 @@ func BenchmarkWithFilter(b *testing.B) {
 	defer bus.Close()
 
 	// Filter only processes even IDs
-	bus.SubscribeWithFilter("bench.filter", func(event BenchEvent) {
-		_ = event.ID * 2
-	}, func(topic string, event BenchEvent) bool {
-		return event.ID%2 == 0
-	})
+	mustSubscribe(b, bus, "bench.filter", benchHandler,
+		HandlerFilter(func(topic string, event BenchEvent) bool {
+			return event.ID%2 == 0
+		}))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -133,9 +123,11 @@ func BenchmarkConcurrentSubscribeUnsubscribe(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			handle := bus.SubscribeWithHandle("bench.concurrent", func(event BenchEvent) {
-				_ = event.ID * 2
-			})
+			handle, err := bus.Subscribe("bench.concurrent", benchHandler)
+			if err != nil {
+				b.Error(err)
+				return
+			}
 
 			// Publish an event
 			bus.Publish("bench.concurrent", BenchEvent{
@@ -153,8 +145,9 @@ func BenchmarkMemoryUsage(b *testing.B) {
 	bus := NewTyped[BenchEvent]()
 	defer bus.Close()
 
-	bus.SubscribeWithHandle("bench.memory", func(event BenchEvent) {
+	mustSubscribe(b, bus, "bench.memory", func(ctx context.Context, event BenchEvent) error {
 		// Minimal processing
+		return nil
 	})
 
 	b.ResetTimer()

--- a/bus.go
+++ b/bus.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -89,241 +90,18 @@ func New(opts ...Option[any]) *EventBus[any] {
 	return NewTyped[any](opts...)
 }
 
-// doSubscribe handles the subscription logic and is utilized by the public Subscribe functions
-func (bus *EventBus[T]) doSubscribe(topic string, fn func(T), handler *eventHandler[T]) error {
+// Subscribe registers fn for topic and returns a handle that cancels the
+// subscription. Behavior is configured through HandlerOption values; with no
+// options the handler runs synchronously at PriorityNormal.
+//
+// Subscribe reports why a subscription was rejected: a nil handler, a filter
+// whose event type does not match the bus, or a closed bus. On error the
+// returned handle is nil; a nil handle is still safe to use.
+func (bus *EventBus[T]) Subscribe(topic string, fn Handler[T], options ...HandlerOption) (*Handle[T], error) {
 	if fn == nil {
-		return fmt.Errorf("event handler is nil")
-	}
-	if handler.ctx == nil {
-		handler.ctx = context.Background()
-	}
-	handler.topic = topic
-
-	bus.lock.Lock()
-	defer bus.lock.Unlock()
-
-	if bus.closed {
-		return fmt.Errorf("event bus is closed")
-	}
-	bus.prepareHandlerLocked(topic, handler)
-
-	// Insert handler based on priority
-	handlers := bus.handlers[topic]
-	inserted := false
-
-	for i, h := range handlers {
-		if handler.priority > h.priority {
-			// Insert before this handler
-			handlers = append(handlers[:i], append([]*eventHandler[T]{handler}, handlers[i:]...)...)
-			inserted = true
-			break
-		}
+		return nil, fmt.Errorf("event handler is nil")
 	}
 
-	if !inserted {
-		handlers = append(handlers, handler)
-	}
-
-	bus.handlers[topic] = handlers
-	bus.metrics.IncrementSubscribers()
-
-	// Log subscription
-	if bus.logger != nil {
-		bus.logger.Debug("Handler subscribed to topic '%s' with priority %v", topic, handler.priority)
-	}
-
-	return nil
-}
-
-// doSubscribeWithHandle handles the subscription logic and returns a handle
-func (bus *EventBus[T]) doSubscribeWithHandle(topic string, fn func(T), handler *eventHandler[T]) *Handle[T] {
-	if fn == nil {
-		return nil
-	}
-	if handler.ctx == nil {
-		handler.ctx = context.Background()
-	}
-	handler.topic = topic
-
-	bus.lock.Lock()
-	defer bus.lock.Unlock()
-
-	if bus.closed {
-		return nil
-	}
-	bus.prepareHandlerLocked(topic, handler)
-
-	// Insert handler based on priority (same logic as doSubscribe)
-	handlers := bus.handlers[topic]
-	inserted := false
-
-	for i, h := range handlers {
-		if handler.priority > h.priority {
-			handlers = append(handlers[:i], append([]*eventHandler[T]{handler}, handlers[i:]...)...)
-			inserted = true
-			break
-		}
-	}
-
-	if !inserted {
-		handlers = append(handlers, handler)
-	}
-
-	bus.handlers[topic] = handlers
-	bus.metrics.IncrementSubscribers()
-
-	// Log subscription
-	if bus.logger != nil {
-		bus.logger.Debug("Handler subscribed to topic '%s' with priority %v (with handle)", topic, handler.priority)
-	}
-
-	return &Handle[T]{
-		bus:      bus,
-		topic:    topic,
-		handler:  handler,
-		priority: handler.priority,
-		filter:   handler.filter,
-		ctx:      handler.ctx,
-	}
-}
-
-func (bus *EventBus[T]) prepareHandlerLocked(topic string, handler *eventHandler[T]) {
-	bus.nextHandlerID++
-	handler.id = topic + "#" + strconv.FormatUint(bus.nextHandlerID, 10)
-	if handler.maxConcurrency > 0 && handler.concurrency == nil {
-		handler.concurrency = make(chan struct{}, handler.maxConcurrency)
-	}
-}
-
-// Subscribe subscribes to a topic.
-func (bus *EventBus[T]) Subscribe(topic string, fn func(T)) error {
-	return bus.doSubscribe(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      false,
-		async:         false,
-		transactional: false,
-		priority:      PriorityNormal,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeWithHandle subscribes to a topic and returns a handle for unsubscription.
-func (bus *EventBus[T]) SubscribeWithHandle(topic string, fn func(T)) *Handle[T] {
-	return bus.doSubscribeWithHandle(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      false,
-		async:         false,
-		transactional: false,
-		priority:      PriorityNormal,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeWithPriority subscribes to a topic with specified priority
-func (bus *EventBus[T]) SubscribeWithPriority(topic string, fn func(T), priority Priority) *Handle[T] {
-	return bus.doSubscribeWithHandle(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      false,
-		async:         false,
-		transactional: false,
-		priority:      priority,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeWithFilter subscribes to a topic with an event filter
-func (bus *EventBus[T]) SubscribeWithFilter(topic string, fn func(T), filter EventFilter[T]) *Handle[T] {
-	return bus.doSubscribeWithHandle(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      false,
-		async:         false,
-		transactional: false,
-		priority:      PriorityNormal,
-		filter:        filter,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeWithContext subscribes to a topic with context for cancellation
-func (bus *EventBus[T]) SubscribeWithContext(ctx context.Context, topic string, fn func(T)) *Handle[T] {
-	return bus.doSubscribeWithHandle(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      false,
-		async:         false,
-		transactional: false,
-		priority:      PriorityNormal,
-		ctx:           ctx,
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeAsync subscribes to a topic with an asynchronous callback
-func (bus *EventBus[T]) SubscribeAsync(topic string, fn func(T), transactional bool) error {
-	return bus.doSubscribe(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      false,
-		async:         true,
-		transactional: transactional,
-		priority:      PriorityNormal,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeAsyncWithHandle subscribes to a topic with an asynchronous callback and returns a handle.
-func (bus *EventBus[T]) SubscribeAsyncWithHandle(topic string, fn func(T), transactional bool) *Handle[T] {
-	return bus.doSubscribeWithHandle(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      false,
-		async:         true,
-		transactional: transactional,
-		priority:      PriorityNormal,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeOnce subscribes to a topic once. Handler will be removed after executing.
-func (bus *EventBus[T]) SubscribeOnce(topic string, fn func(T)) error {
-	return bus.doSubscribe(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      true,
-		async:         false,
-		transactional: false,
-		priority:      PriorityNormal,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeOnceAsync subscribes to a topic once with an asynchronous callback
-func (bus *EventBus[T]) SubscribeOnceAsync(topic string, fn func(T)) error {
-	return bus.doSubscribe(topic, fn, &eventHandler[T]{
-		callBack:      fn,
-		flagOnce:      true,
-		async:         true,
-		transactional: false,
-		priority:      PriorityNormal,
-		ctx:           context.Background(),
-		recoverPolicy: RecoverAndContinue,
-		Mutex:         sync.Mutex{},
-	})
-}
-
-// SubscribeWithOptions subscribes to a topic with handler-level execution controls.
-func (bus *EventBus[T]) SubscribeWithOptions(topic string, fn func(T), options ...HandlerOption) (*Handle[T], error) {
 	opts := defaultHandlerOptions()
 	for _, option := range options {
 		if option != nil {
@@ -334,26 +112,68 @@ func (bus *EventBus[T]) SubscribeWithOptions(topic string, fn func(T), options .
 		opts.ctx = context.Background()
 	}
 
+	var filter EventFilter[T]
+	if opts.filter != nil {
+		typed, ok := opts.filter.(EventFilter[T])
+		if !ok {
+			return nil, fmt.Errorf("handler filter is %T, want a filter for event type %T", opts.filter, *new(T))
+		}
+		filter = typed
+	}
+
 	handler := &eventHandler[T]{
 		callBack:       fn,
+		topic:          topic,
 		flagOnce:       opts.once,
 		async:          opts.async,
 		transactional:  opts.transactional,
 		priority:       opts.priority,
+		filter:         filter,
 		ctx:            opts.ctx,
 		timeout:        opts.timeout,
 		recoverPolicy:  opts.recoverPolicy,
 		maxConcurrency: opts.maxConcurrency,
 		Mutex:          sync.Mutex{},
 	}
-	handle := bus.doSubscribeWithHandle(topic, fn, handler)
-	if handle == nil {
-		if fn == nil {
-			return nil, fmt.Errorf("event handler is nil")
-		}
+
+	bus.lock.Lock()
+	defer bus.lock.Unlock()
+
+	if bus.closed {
 		return nil, fmt.Errorf("event bus is closed")
 	}
-	return handle, nil
+	bus.prepareHandlerLocked(topic, handler)
+
+	// Insert before the first handler with strictly lower priority, so equal
+	// priorities keep subscription order.
+	handlers := bus.handlers[topic]
+	inserted := false
+	for i, h := range handlers {
+		if handler.priority > h.priority {
+			handlers = append(handlers[:i], append([]*eventHandler[T]{handler}, handlers[i:]...)...)
+			inserted = true
+			break
+		}
+	}
+	if !inserted {
+		handlers = append(handlers, handler)
+	}
+	bus.handlers[topic] = handlers
+	bus.metrics.IncrementSubscribers()
+
+	if bus.logger != nil {
+		bus.logger.Debug("Handler subscribed to topic '%s' with priority %v", topic, handler.priority)
+	}
+
+	return &Handle[T]{bus: bus, topic: topic, handler: handler}, nil
+}
+
+func (bus *EventBus[T]) prepareHandlerLocked(topic string, handler *eventHandler[T]) {
+	bus.nextHandlerID++
+	handler.id = topic + "#" + strconv.FormatUint(bus.nextHandlerID, 10)
+	if handler.maxConcurrency > 0 && handler.concurrency == nil {
+		handler.concurrency = make(chan struct{}, handler.maxConcurrency)
+	}
 }
 
 // HasCallback returns true if exists any callback subscribed to the topic.
@@ -367,12 +187,17 @@ func (bus *EventBus[T]) HasCallback(topic string) bool {
 	return false
 }
 
-// Publish executes callback defined for a topic.
-func (bus *EventBus[T]) Publish(topic string, event T) {
-	bus.PublishWithContext(context.Background(), topic, event)
+// Publish delivers event to the topic's handlers. The returned error joins
+// the failures of the synchronous handlers, and is safe to ignore when
+// delivery failures do not matter to the caller. Asynchronous handler
+// failures are reported through the ErrorHandler instead.
+func (bus *EventBus[T]) Publish(topic string, event T) error {
+	return bus.PublishWithContext(context.Background(), topic, event)
 }
 
-// PublishWithContext publishes an event with context
+// PublishWithContext publishes an event with context. Canceling the context
+// aborts dispatch to the remaining handlers and cancels the context passed to
+// the currently running synchronous handler.
 func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, event T) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -451,12 +276,17 @@ func runMiddlewares(middlewares []EventMiddleware[any], topic string, event any,
 }
 
 func (bus *EventBus[T]) dispatch(ctx context.Context, topic string, event T, handlers []*eventHandler[T], closeCh <-chan struct{}, logger Logger, errorHandler ErrorHandler, metrics Metrics) error {
+	var errs []error
+	abort := func(err error) error {
+		return errors.Join(append(errs, err)...)
+	}
+
 	for _, handler := range handlers {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return abort(ctx.Err())
 		case <-closeCh:
-			return fmt.Errorf("event bus is closed")
+			return abort(fmt.Errorf("event bus is closed"))
 		default:
 		}
 
@@ -477,21 +307,25 @@ func (bus *EventBus[T]) dispatch(ctx context.Context, topic string, event T, han
 		}
 
 		if !handler.async {
-			if err := bus.doPublish(ctx, closeCh, handler, topic, event, logger, errorHandler, metrics); err != nil {
-				return err
+			err, stop := bus.doPublish(ctx, closeCh, handler, topic, event, logger, errorHandler, metrics)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			if stop {
+				return errors.Join(errs...)
 			}
 			continue
 		}
 
 		if !bus.addAsync() {
-			return fmt.Errorf("event bus is closed")
+			return abort(fmt.Errorf("event bus is closed"))
 		}
 		if handler.transactional {
 			handler.Lock()
 		}
 		go bus.doPublishAsync(handler, topic, event, closeCh, logger, errorHandler, metrics)
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (bus *EventBus[T]) addAsync() bool {
@@ -519,7 +353,9 @@ func (e *handlerPanicError) Error() string {
 	return fmt.Sprintf("panic: %v", e.value)
 }
 
-func (bus *EventBus[T]) doPublish(ctx context.Context, closeCh <-chan struct{}, handler *eventHandler[T], topic string, event T, logger Logger, errorHandler ErrorHandler, metrics Metrics) error {
+// doPublish runs one handler and records the outcome. The second return value
+// reports whether dispatch must stop (a recovered panic under RecoverAndStop).
+func (bus *EventBus[T]) doPublish(ctx context.Context, closeCh <-chan struct{}, handler *eventHandler[T], topic string, event T, logger Logger, errorHandler ErrorHandler, metrics Metrics) (error, bool) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -528,40 +364,39 @@ func (bus *EventBus[T]) doPublish(ctx context.Context, closeCh <-chan struct{}, 
 	err := bus.runHandler(ctx, closeCh, handler, event)
 	duration := time.Since(start)
 
-	if err != nil {
+	if err == nil {
 		if logger != nil {
-			if _, ok := err.(*handlerPanicError); ok {
-				logger.Error("Handler panic for topic '%s': %v", topic, err)
-			} else {
-				logger.Error("Handler failed for topic '%s': %v", topic, err)
-			}
+			logger.Debug("Handler executed successfully for topic '%s'", topic)
 		}
-		if errorHandler != nil {
-			errorHandler(&EventError{
-				Topic:   topic,
-				Event:   event,
-				Handler: handler.callBack,
-				Err:     err,
-			})
-		}
-		metrics.IncrementFailed()
+		metrics.IncrementProcessed()
 		if detailed, ok := metrics.(DetailedMetrics); ok {
-			detailed.RecordFailed(topic, handler.id, duration)
+			detailed.RecordProcessed(topic, handler.id, duration)
 		}
-		if _, ok := err.(*handlerPanicError); ok && handler.recoverPolicy == RecoverAndContinue {
-			return nil
-		}
-		return err
+		return nil, false
 	}
 
+	var panicErr *handlerPanicError
+	isPanic := errors.As(err, &panicErr)
 	if logger != nil {
-		logger.Debug("Handler executed successfully for topic '%s'", topic)
+		if isPanic {
+			logger.Error("Handler panic for topic '%s': %v", topic, err)
+		} else {
+			logger.Error("Handler failed for topic '%s': %v", topic, err)
+		}
 	}
-	metrics.IncrementProcessed()
+	if errorHandler != nil {
+		errorHandler(&EventError{
+			Topic:   topic,
+			Event:   event,
+			Handler: handler.callBack,
+			Err:     err,
+		})
+	}
+	metrics.IncrementFailed()
 	if detailed, ok := metrics.(DetailedMetrics); ok {
-		detailed.RecordProcessed(topic, handler.id, duration)
+		detailed.RecordFailed(topic, handler.id, duration)
 	}
-	return nil
+	return err, isPanic && handler.recoverPolicy == RecoverAndStop
 }
 
 func (bus *EventBus[T]) runHandler(ctx context.Context, closeCh <-chan struct{}, handler *eventHandler[T], event T) error {
@@ -615,8 +450,7 @@ func (bus *EventBus[T]) runHandlerWithoutTimeout(ctx context.Context, closeCh <-
 			err = &handlerPanicError{value: r}
 		}
 	}()
-	handler.callBack(event)
-	return nil
+	return handler.callBack(ctx, event)
 }
 
 func acquireConcurrency[T any](ctx context.Context, closeCh <-chan struct{}, handler *eventHandler[T]) error {
@@ -641,7 +475,13 @@ func (bus *EventBus[T]) doPublishAsync(handler *eventHandler[T], topic string, e
 		}
 	}()
 
-	_ = bus.doPublish(context.Background(), closeCh, handler, topic, event, logger, errorHandler, metrics)
+	// The publish call may already have returned, so asynchronous handlers run
+	// under the subscription context rather than the publish context.
+	ctx := handler.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, _ = bus.doPublish(ctx, closeCh, handler, topic, event, logger, errorHandler, metrics)
 }
 
 func (bus *EventBus[T]) removeHandler(topic string, target *eventHandler[T]) bool {

--- a/bus_test.go
+++ b/bus_test.go
@@ -2,7 +2,9 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,6 +16,19 @@ type TestEvent struct {
 	Value int
 }
 
+// discard is a handler that succeeds without doing anything.
+func discard[T any](context.Context, T) error { return nil }
+
+// mustSubscribe fails the test when the subscription is rejected.
+func mustSubscribe[T any](tb testing.TB, b *EventBus[T], topic string, fn Handler[T], opts ...HandlerOption) *Handle[T] {
+	tb.Helper()
+	handle, err := b.Subscribe(topic, fn, opts...)
+	if err != nil {
+		tb.Fatalf("Subscribe(%q): %v", topic, err)
+	}
+	return handle
+}
+
 func TestBasicPublishSubscribe(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()
@@ -22,13 +37,16 @@ func TestBasicPublishSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	handle := bus.SubscribeWithHandle("test.topic", func(event TestEvent) {
+	handle := mustSubscribe(t, bus, "test.topic", func(ctx context.Context, event TestEvent) error {
 		received = event
 		wg.Done()
+		return nil
 	})
 	defer handle.Unsubscribe()
 
-	bus.Publish("test.topic", TestEvent{ID: "test1", Value: 42})
+	if err := bus.Publish("test.topic", TestEvent{ID: "test1", Value: 42}); err != nil {
+		t.Fatalf("Unexpected publish error: %v", err)
+	}
 	wg.Wait()
 
 	if received.ID != "test1" || received.Value != 42 {
@@ -42,34 +60,19 @@ func TestPriorityHandling(t *testing.T) {
 
 	var executionOrder []string
 	var mu sync.Mutex
+	record := func(name string) Handler[TestEvent] {
+		return func(ctx context.Context, event TestEvent) error {
+			mu.Lock()
+			executionOrder = append(executionOrder, name)
+			mu.Unlock()
+			return nil
+		}
+	}
 
-	// Low priority
-	bus.SubscribeWithPriority("priority.test", func(event TestEvent) {
-		mu.Lock()
-		executionOrder = append(executionOrder, "low")
-		mu.Unlock()
-	}, PriorityLow)
-
-	// High priority
-	bus.SubscribeWithPriority("priority.test", func(event TestEvent) {
-		mu.Lock()
-		executionOrder = append(executionOrder, "high")
-		mu.Unlock()
-	}, PriorityHigh)
-
-	// Normal priority
-	bus.SubscribeWithPriority("priority.test", func(event TestEvent) {
-		mu.Lock()
-		executionOrder = append(executionOrder, "normal")
-		mu.Unlock()
-	}, PriorityNormal)
-
-	// Critical priority
-	bus.SubscribeWithPriority("priority.test", func(event TestEvent) {
-		mu.Lock()
-		executionOrder = append(executionOrder, "critical")
-		mu.Unlock()
-	}, PriorityCritical)
+	mustSubscribe(t, bus, "priority.test", record("low"), HandlerPriority(PriorityLow))
+	mustSubscribe(t, bus, "priority.test", record("high"), HandlerPriority(PriorityHigh))
+	mustSubscribe(t, bus, "priority.test", record("normal"), HandlerPriority(PriorityNormal))
+	mustSubscribe(t, bus, "priority.test", record("critical"), HandlerPriority(PriorityCritical))
 
 	bus.Publish("priority.test", TestEvent{ID: "priority", Value: 1})
 	bus.WaitAsync()
@@ -98,19 +101,21 @@ func TestEventFiltering(t *testing.T) {
 	var mu sync.Mutex
 
 	// Filter: only process events with Value > 10
-	bus.SubscribeWithFilter("filter.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "filter.test", func(ctx context.Context, event TestEvent) error {
 		mu.Lock()
 		filteredEvents = append(filteredEvents, event)
 		mu.Unlock()
-	}, func(topic string, event TestEvent) bool {
+		return nil
+	}, HandlerFilter(func(topic string, event TestEvent) bool {
 		return event.Value > 10
-	})
+	}))
 
 	// Process all events
-	bus.SubscribeWithHandle("filter.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "filter.test", func(ctx context.Context, event TestEvent) error {
 		mu.Lock()
 		allEvents = append(allEvents, event)
 		mu.Unlock()
+		return nil
 	})
 
 	// Publish test events
@@ -145,6 +150,20 @@ func TestEventFiltering(t *testing.T) {
 	}
 }
 
+func TestFilterTypeMismatchIsRejected(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	handle, err := bus.Subscribe("filter.mismatch", discard[TestEvent],
+		HandlerFilter(func(topic string, event string) bool { return true }))
+	if err == nil {
+		t.Fatal("Expected an error for a filter with the wrong event type")
+	}
+	if handle != nil {
+		t.Fatal("Expected a nil handle for a rejected subscription")
+	}
+}
+
 func TestContextCancellation(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()
@@ -152,9 +171,10 @@ func TestContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var processedCount int32
 
-	handle := bus.SubscribeWithContext(ctx, "context.test", func(event TestEvent) {
+	handle := mustSubscribe(t, bus, "context.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&processedCount, 1)
-	})
+		return nil
+	}, HandlerContext(ctx))
 	defer handle.Unsubscribe()
 
 	// Publish first event (should be processed)
@@ -177,7 +197,7 @@ func TestContextCancellation(t *testing.T) {
 	}
 }
 
-func TestErrorHandling(t *testing.T) {
+func TestPanicIsRecoveredAndReported(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()
 
@@ -190,18 +210,24 @@ func TestErrorHandling(t *testing.T) {
 	})
 
 	// Subscribe a handler that will panic
-	bus.SubscribeWithHandle("error.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "error.test", func(ctx context.Context, event TestEvent) error {
 		if event.Value < 0 {
 			panic("negative value")
 		}
 		atomic.AddInt32(&normalCount, 1)
+		return nil
 	})
 
 	// Publish normal event
-	bus.Publish("error.test", TestEvent{ID: "normal", Value: 5})
+	if err := bus.Publish("error.test", TestEvent{ID: "normal", Value: 5}); err != nil {
+		t.Fatalf("Unexpected publish error: %v", err)
+	}
 
-	// Publish event that will cause panic
-	bus.Publish("error.test", TestEvent{ID: "panic", Value: -1})
+	// Publish event that will cause panic: the panic is recovered, reported,
+	// and joined into the publish error.
+	if err := bus.Publish("error.test", TestEvent{ID: "panic", Value: -1}); err == nil {
+		t.Fatal("Expected the recovered panic in the publish error")
+	}
 
 	bus.WaitAsync()
 
@@ -214,17 +240,84 @@ func TestErrorHandling(t *testing.T) {
 	}
 }
 
+func TestHandlerErrorsAreJoinedAndDispatchContinues(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	errFirst := errors.New("first failure")
+	errSecond := errors.New("second failure")
+	var reported int32
+	var thirdRan int32
+
+	bus.SetErrorHandler(func(err *EventError) {
+		atomic.AddInt32(&reported, 1)
+	})
+
+	mustSubscribe(t, bus, "errors.join", func(ctx context.Context, event TestEvent) error {
+		return errFirst
+	}, HandlerPriority(PriorityHigh))
+	mustSubscribe(t, bus, "errors.join", func(ctx context.Context, event TestEvent) error {
+		return errSecond
+	}, HandlerPriority(PriorityNormal))
+	mustSubscribe(t, bus, "errors.join", func(ctx context.Context, event TestEvent) error {
+		atomic.AddInt32(&thirdRan, 1)
+		return nil
+	}, HandlerPriority(PriorityLow))
+
+	err := bus.Publish("errors.join", TestEvent{ID: "join", Value: 1})
+	if !errors.Is(err, errFirst) || !errors.Is(err, errSecond) {
+		t.Fatalf("Expected both handler errors in the joined publish error, got %v", err)
+	}
+	if atomic.LoadInt32(&thirdRan) != 1 {
+		t.Fatal("Expected dispatch to continue past failing handlers")
+	}
+	if atomic.LoadInt32(&reported) != 2 {
+		t.Fatalf("Expected 2 errors reported to the ErrorHandler, got %d", reported)
+	}
+
+	_, _, failed, _ := bus.GetMetrics().GetStats()
+	if failed != 2 {
+		t.Fatalf("Expected 2 failed deliveries in metrics, got %d", failed)
+	}
+}
+
+func TestAsyncHandlerErrorGoesToErrorHandler(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	errAsync := errors.New("async failure")
+	reported := make(chan error, 1)
+	bus.SetErrorHandler(func(err *EventError) {
+		reported <- err.Err
+	})
+
+	mustSubscribe(t, bus, "errors.async", func(ctx context.Context, event TestEvent) error {
+		return errAsync
+	}, HandlerAsync(false))
+
+	// The async handler's failure is not part of the publish error.
+	if err := bus.Publish("errors.async", TestEvent{ID: "async", Value: 1}); err != nil {
+		t.Fatalf("Expected no publish error for an async handler failure, got %v", err)
+	}
+	bus.WaitAsync()
+
+	select {
+	case err := <-reported:
+		if !errors.Is(err, errAsync) {
+			t.Fatalf("Expected the async handler error, got %v", err)
+		}
+	default:
+		t.Fatal("Expected the async handler error to reach the ErrorHandler")
+	}
+}
+
 func TestMetrics(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()
 
 	// Subscribe handlers
-	handle1 := bus.SubscribeWithHandle("metrics.test", func(event TestEvent) {
-		// Normal processing
-	})
-	handle2 := bus.SubscribeWithHandle("metrics.test", func(event TestEvent) {
-		// Normal processing
-	})
+	handle1 := mustSubscribe(t, bus, "metrics.test", discard[TestEvent])
+	handle2 := mustSubscribe(t, bus, "metrics.test", discard[TestEvent])
 
 	defer func() {
 		handle1.Unsubscribe()
@@ -279,8 +372,9 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	// Subscribe handler
-	bus.SubscribeWithHandle("middleware.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "middleware.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&handlerCalled, 1)
+		return nil
 	})
 
 	// Publish event
@@ -305,8 +399,9 @@ func TestMiddlewareCanSkipHandlers(t *testing.T) {
 	bus.AddMiddleware(func(topic string, event interface{}, next func()) error {
 		return nil
 	})
-	bus.SubscribeWithHandle("middleware.skip.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "middleware.skip.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&handlerCalled, 1)
+		return nil
 	})
 
 	bus.Publish("middleware.skip.test", TestEvent{ID: "test", Value: 1})
@@ -326,8 +421,9 @@ func TestMiddlewareNextIsIdempotent(t *testing.T) {
 		next()
 		return nil
 	})
-	bus.SubscribeWithHandle("middleware.next.once", func(event TestEvent) {
+	mustSubscribe(t, bus, "middleware.next.once", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&handlerCalled, 1)
+		return nil
 	})
 
 	bus.Publish("middleware.next.once", TestEvent{ID: "test", Value: 1})
@@ -354,8 +450,9 @@ func TestMiddlewareNextIsConcurrentSafe(t *testing.T) {
 		wg.Wait()
 		return nil
 	})
-	bus.SubscribeWithHandle("middleware.next.concurrent", func(event TestEvent) {
+	mustSubscribe(t, bus, "middleware.next.concurrent", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&handlerCalled, 1)
+		return nil
 	})
 
 	bus.Publish("middleware.next.concurrent", TestEvent{ID: "test", Value: 1})
@@ -370,12 +467,13 @@ func TestPublishDoesNotHoldBusLockDuringHandler(t *testing.T) {
 	defer bus.Close()
 
 	done := make(chan struct{})
-	bus.SubscribeWithHandle("lock.test", func(event TestEvent) {
-		handle := bus.SubscribeWithHandle("lock.test.extra", func(event TestEvent) {})
-		if handle != nil {
+	mustSubscribe(t, bus, "lock.test", func(ctx context.Context, event TestEvent) error {
+		handle, err := bus.Subscribe("lock.test.extra", discard[TestEvent])
+		if err == nil {
 			handle.Unsubscribe()
 		}
 		close(done)
+		return nil
 	})
 
 	go bus.Publish("lock.test", TestEvent{ID: "lock", Value: 1})
@@ -392,9 +490,10 @@ func TestPublishWithTimeout(t *testing.T) {
 	defer bus.Close()
 
 	// Subscribe a synchronous handler that will block for a long time
-	bus.SubscribeWithHandle("timeout.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "timeout.test", func(ctx context.Context, event TestEvent) error {
 		// Simulate blocking operation
 		time.Sleep(100 * time.Millisecond)
+		return nil
 	})
 
 	// Test timeout publish (timeout shorter than processing time)
@@ -402,29 +501,28 @@ func TestPublishWithTimeout(t *testing.T) {
 	err := bus.PublishWithTimeout("timeout.test", TestEvent{ID: "timeout", Value: 1}, 50*time.Millisecond)
 	elapsed := time.Since(start)
 
-	if err == nil {
-		t.Error("Expected timeout error, got nil")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Expected context.DeadlineExceeded in the publish error, got %v", err)
 	}
 
 	// Verify it returns around timeout time
 	if elapsed > 80*time.Millisecond {
 		t.Errorf("Expected timeout around 50ms, but took %v", elapsed)
 	}
+	bus.WaitAsync()
 }
 
 func TestHandlerTimeoutOption(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()
 
-	_, err := bus.SubscribeWithOptions("handler.timeout", func(event TestEvent) {
+	mustSubscribe(t, bus, "handler.timeout", func(ctx context.Context, event TestEvent) error {
 		time.Sleep(100 * time.Millisecond)
+		return nil
 	}, HandlerTimeout(20*time.Millisecond))
-	if err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
 
 	start := time.Now()
-	err = bus.PublishWithContext(context.Background(), "handler.timeout", TestEvent{ID: "timeout", Value: 1})
+	err := bus.PublishWithContext(context.Background(), "handler.timeout", TestEvent{ID: "timeout", Value: 1})
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatal("Expected handler timeout error")
@@ -437,6 +535,34 @@ func TestHandlerTimeoutOption(t *testing.T) {
 	if failed != 1 {
 		t.Fatalf("Expected 1 failed handler, got %d", failed)
 	}
+	bus.WaitAsync()
+}
+
+func TestHandlerTimeoutCancelsHandlerContext(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	canceled := make(chan struct{})
+	mustSubscribe(t, bus, "handler.timeout.ctx", func(ctx context.Context, event TestEvent) error {
+		select {
+		case <-ctx.Done():
+			close(canceled)
+			return ctx.Err()
+		case <-time.After(time.Second):
+			return fmt.Errorf("handler context was never canceled")
+		}
+	}, HandlerTimeout(10*time.Millisecond))
+
+	if err := bus.PublishWithContext(context.Background(), "handler.timeout.ctx", TestEvent{ID: "ctx", Value: 1}); err == nil {
+		t.Fatal("Expected handler timeout error")
+	}
+
+	bus.WaitAsync()
+	select {
+	case <-canceled:
+	default:
+		t.Fatal("Expected the handler context to be canceled at the timeout")
+	}
 }
 
 func TestHandlerTimeoutGoroutineIsWaited(t *testing.T) {
@@ -444,13 +570,11 @@ func TestHandlerTimeoutGoroutineIsWaited(t *testing.T) {
 	defer bus.Close()
 
 	done := make(chan struct{})
-	_, err := bus.SubscribeWithOptions("handler.timeout.wait", func(event TestEvent) {
+	mustSubscribe(t, bus, "handler.timeout.wait", func(ctx context.Context, event TestEvent) error {
 		time.Sleep(60 * time.Millisecond)
 		close(done)
+		return nil
 	}, HandlerTimeout(10*time.Millisecond))
-	if err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
 
 	if err := bus.PublishWithContext(context.Background(), "handler.timeout.wait", TestEvent{ID: "timeout", Value: 1}); err == nil {
 		t.Fatal("Expected handler timeout error")
@@ -469,13 +593,12 @@ func TestHandlerTimeoutCancelsConcurrencyWait(t *testing.T) {
 	defer bus.Close()
 
 	block := make(chan struct{})
-	if _, err := bus.SubscribeWithOptions("handler.timeout.concurrency", func(event TestEvent) {
+	mustSubscribe(t, bus, "handler.timeout.concurrency", func(ctx context.Context, event TestEvent) error {
 		if event.ID == "first" {
 			<-block
 		}
-	}, HandlerTimeout(10*time.Millisecond), HandlerMaxConcurrency(1)); err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
+		return nil
+	}, HandlerTimeout(10*time.Millisecond), HandlerMaxConcurrency(1))
 
 	firstDone := make(chan error, 1)
 	go func() {
@@ -514,8 +637,9 @@ func TestPublishWithNilContextUsesBackground(t *testing.T) {
 	defer bus.Close()
 
 	var called int32
-	bus.SubscribeWithHandle("nil.publish.context", func(event TestEvent) {
+	mustSubscribe(t, bus, "nil.publish.context", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&called, 1)
+		return nil
 	})
 
 	if err := bus.PublishWithContext(nil, "nil.publish.context", TestEvent{ID: "nil", Value: 1}); err != nil {
@@ -531,22 +655,41 @@ func TestRecoverAndStopOption(t *testing.T) {
 	defer bus.Close()
 
 	var secondCalled int32
-	_, err := bus.SubscribeWithOptions("recover.stop", func(event TestEvent) {
+	mustSubscribe(t, bus, "recover.stop", func(ctx context.Context, event TestEvent) error {
 		panic("stop")
 	}, HandlerRecoverPolicy(RecoverAndStop), HandlerPriority(PriorityHigh))
-	if err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
-	bus.SubscribeWithPriority("recover.stop", func(event TestEvent) {
+	mustSubscribe(t, bus, "recover.stop", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&secondCalled, 1)
-	}, PriorityLow)
+		return nil
+	}, HandlerPriority(PriorityLow))
 
-	err = bus.PublishWithContext(context.Background(), "recover.stop", TestEvent{ID: "panic", Value: 1})
+	err := bus.PublishWithContext(context.Background(), "recover.stop", TestEvent{ID: "panic", Value: 1})
 	if err == nil {
 		t.Fatal("Expected recovered panic to stop publish")
 	}
 	if atomic.LoadInt32(&secondCalled) != 0 {
 		t.Fatal("Expected lower priority handler to be skipped")
+	}
+}
+
+func TestReturnedErrorDoesNotStopDispatchUnderRecoverAndStop(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	var secondCalled int32
+	mustSubscribe(t, bus, "recover.stop.error", func(ctx context.Context, event TestEvent) error {
+		return errors.New("business failure")
+	}, HandlerRecoverPolicy(RecoverAndStop), HandlerPriority(PriorityHigh))
+	mustSubscribe(t, bus, "recover.stop.error", func(ctx context.Context, event TestEvent) error {
+		atomic.AddInt32(&secondCalled, 1)
+		return nil
+	}, HandlerPriority(PriorityLow))
+
+	if err := bus.Publish("recover.stop.error", TestEvent{ID: "err", Value: 1}); err == nil {
+		t.Fatal("Expected the handler error in the publish error")
+	}
+	if atomic.LoadInt32(&secondCalled) != 1 {
+		t.Fatal("RecoverAndStop governs panics; a returned error must not stop dispatch")
 	}
 }
 
@@ -556,7 +699,7 @@ func TestHandlerMaxConcurrencyOption(t *testing.T) {
 
 	var current int32
 	var maxSeen int32
-	if _, err := bus.SubscribeWithOptions("max.concurrency", func(event TestEvent) {
+	mustSubscribe(t, bus, "max.concurrency", func(ctx context.Context, event TestEvent) error {
 		now := atomic.AddInt32(&current, 1)
 		for {
 			seen := atomic.LoadInt32(&maxSeen)
@@ -566,9 +709,8 @@ func TestHandlerMaxConcurrencyOption(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 		atomic.AddInt32(&current, -1)
-	}, HandlerAsync(false), HandlerMaxConcurrency(1)); err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
+		return nil
+	}, HandlerAsync(false), HandlerMaxConcurrency(1))
 
 	for i := 0; i < 3; i++ {
 		bus.Publish("max.concurrency", TestEvent{ID: fmt.Sprintf("%d", i), Value: i})
@@ -586,16 +728,16 @@ func TestHandleUnsubscribe(t *testing.T) {
 
 	var count int32
 
-	handle := bus.SubscribeWithHandle("unsubscribe.test", func(event TestEvent) {
+	handle := mustSubscribe(t, bus, "unsubscribe.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&count, 1)
+		return nil
 	})
 
 	// Publish first event
 	bus.Publish("unsubscribe.test", TestEvent{ID: "first", Value: 1})
 
 	// Unsubscribe
-	err := handle.Unsubscribe()
-	if err != nil {
+	if err := handle.Unsubscribe(); err != nil {
 		t.Errorf("Unexpected error during unsubscribe: %v", err)
 	}
 
@@ -614,8 +756,7 @@ func TestHandleUnsubscribe(t *testing.T) {
 	}
 
 	// Unsubscribing again should return error
-	err = handle.Unsubscribe()
-	if err == nil {
+	if err := handle.Unsubscribe(); err == nil {
 		t.Error("Expected error when unsubscribing already unsubscribed handle")
 	}
 }
@@ -626,34 +767,31 @@ func TestBusClose(t *testing.T) {
 	var processed int32
 
 	// Subscribe handler
-	bus.SubscribeWithHandle("close.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "close.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&processed, 1)
+		return nil
 	})
 
 	// Publish event
 	bus.Publish("close.test", TestEvent{ID: "before_close", Value: 1})
 
 	// Close bus
-	err := bus.Close()
-	if err != nil {
+	if err := bus.Close(); err != nil {
 		t.Errorf("Unexpected error during close: %v", err)
 	}
 
 	// Try to publish again (should fail)
-	err = bus.PublishWithContext(context.Background(), "close.test", TestEvent{ID: "after_close", Value: 2})
-	if err == nil {
+	if err := bus.PublishWithContext(context.Background(), "close.test", TestEvent{ID: "after_close", Value: 2}); err == nil {
 		t.Error("Expected error when publishing to closed bus")
 	}
 
 	// Try to subscribe (should fail)
-	err = bus.Subscribe("close.test", func(event TestEvent) {})
-	if err == nil {
+	if _, err := bus.Subscribe("close.test", discard[TestEvent]); err == nil {
 		t.Error("Expected error when subscribing to closed bus")
 	}
 
 	// Closing again should return error
-	err = bus.Close()
-	if err == nil {
+	if err := bus.Close(); err == nil {
 		t.Error("Expected error when closing already closed bus")
 	}
 }
@@ -663,13 +801,12 @@ func TestBusCloseDoesNotDeadlockWhenAsyncHandlerUsesBus(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 
-	if err := bus.SubscribeAsync("close.deadlock", func(event TestEvent) {
+	mustSubscribe(t, bus, "close.deadlock", func(ctx context.Context, event TestEvent) error {
 		close(started)
 		<-release
 		_ = bus.GetSubscriberCount("close.deadlock")
-	}, false); err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
+		return nil
+	}, HandlerAsync(false))
 
 	bus.Publish("close.deadlock", TestEvent{ID: "close", Value: 1})
 	<-started
@@ -694,8 +831,8 @@ func TestBusCloseDoesNotDeadlockWhenAsyncHandlerUsesBus(t *testing.T) {
 func TestBusCloseClearsSubscriberMetrics(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 
-	bus.SubscribeWithHandle("close.metrics", func(event TestEvent) {})
-	bus.SubscribeWithHandle("close.metrics", func(event TestEvent) {})
+	mustSubscribe(t, bus, "close.metrics", discard[TestEvent])
+	mustSubscribe(t, bus, "close.metrics", discard[TestEvent])
 
 	if err := bus.Close(); err != nil {
 		t.Fatalf("Unexpected close error: %v", err)
@@ -719,11 +856,10 @@ func TestPublishDoesNotStartAsyncHandlerAfterClose(t *testing.T) {
 		next()
 		return nil
 	})
-	if err := bus.SubscribeAsync("close.publish", func(event TestEvent) {
+	mustSubscribe(t, bus, "close.publish", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&processed, 1)
-	}, false); err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
+		return nil
+	}, HandlerAsync(false))
 
 	published := make(chan error, 1)
 	go func() {
@@ -755,8 +891,9 @@ func TestConcurrentPublishSubscribe(t *testing.T) {
 	// Create multiple subscribers
 	numSubscribers := 10
 	for i := 0; i < numSubscribers; i++ {
-		bus.SubscribeWithHandle("concurrent.test", func(event TestEvent) {
+		mustSubscribe(t, bus, "concurrent.test", func(ctx context.Context, event TestEvent) error {
 			atomic.AddInt64(&processed, 1)
+			return nil
 		})
 	}
 
@@ -797,9 +934,10 @@ func TestNew(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	handle := bus.SubscribeWithHandle("new.test", func(event interface{}) {
+	handle := mustSubscribe(t, bus, "new.test", func(ctx context.Context, event any) error {
 		received = event
 		wg.Done()
+		return nil
 	})
 	defer handle.Unsubscribe()
 
@@ -830,14 +968,11 @@ func TestSubscribeAsync(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Test non-transactional async
-	err := bus.SubscribeAsync("async.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "async.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&processed, 1)
 		wg.Done()
-	}, false)
-
-	if err != nil {
-		t.Errorf("Unexpected error in SubscribeAsync: %v", err)
-	}
+		return nil
+	}, HandlerAsync(false))
 
 	wg.Add(1)
 	bus.Publish("async.test", TestEvent{ID: "async1", Value: 1})
@@ -848,64 +983,14 @@ func TestSubscribeAsync(t *testing.T) {
 	}
 
 	// Test transactional async
-	err = bus.SubscribeAsync("async.transactional", func(event TestEvent) {
+	mustSubscribe(t, bus, "async.transactional", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&processed, 1)
 		wg.Done()
-	}, true)
-
-	if err != nil {
-		t.Errorf("Unexpected error in SubscribeAsync with transactional: %v", err)
-	}
+		return nil
+	}, HandlerAsync(true))
 
 	wg.Add(1)
 	bus.Publish("async.transactional", TestEvent{ID: "async2", Value: 2})
-	wg.Wait()
-
-	if count := atomic.LoadInt32(&processed); count != 2 {
-		t.Errorf("Expected 2 processed events, got %d", count)
-	}
-}
-
-// TestSubscribeAsyncWithHandle tests asynchronous subscription with handle
-func TestSubscribeAsyncWithHandle(t *testing.T) {
-	bus := NewTyped[TestEvent]()
-	defer bus.Close()
-
-	var processed int32
-	var wg sync.WaitGroup
-
-	// Test non-transactional async with handle
-	handle := bus.SubscribeAsyncWithHandle("async.handle.test", func(event TestEvent) {
-		atomic.AddInt32(&processed, 1)
-		wg.Done()
-	}, false)
-
-	if handle == nil {
-		t.Error("Expected handle to be returned, got nil")
-	}
-	defer handle.Unsubscribe()
-
-	wg.Add(1)
-	bus.Publish("async.handle.test", TestEvent{ID: "async_handle1", Value: 1})
-	wg.Wait()
-
-	if count := atomic.LoadInt32(&processed); count != 1 {
-		t.Errorf("Expected 1 processed event, got %d", count)
-	}
-
-	// Test transactional async with handle
-	handle2 := bus.SubscribeAsyncWithHandle("async.handle.transactional", func(event TestEvent) {
-		atomic.AddInt32(&processed, 1)
-		wg.Done()
-	}, true)
-
-	if handle2 == nil {
-		t.Error("Expected handle2 to be returned, got nil")
-	}
-	defer handle2.Unsubscribe()
-
-	wg.Add(1)
-	bus.Publish("async.handle.transactional", TestEvent{ID: "async_handle2", Value: 2})
 	wg.Wait()
 
 	if count := atomic.LoadInt32(&processed); count != 2 {
@@ -920,13 +1005,10 @@ func TestSubscribeOnce(t *testing.T) {
 
 	var processed int32
 
-	err := bus.SubscribeOnce("once.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "once.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&processed, 1)
-	})
-
-	if err != nil {
-		t.Errorf("Unexpected error in SubscribeOnce: %v", err)
-	}
+		return nil
+	}, HandlerOnce())
 
 	// Publish first event (should be processed)
 	bus.Publish("once.test", TestEvent{ID: "once1", Value: 1})
@@ -942,7 +1024,7 @@ func TestSubscribeOnce(t *testing.T) {
 
 	// Verify no callback exists for the topic anymore
 	if bus.HasCallback("once.test") {
-		t.Error("Expected no callback after SubscribeOnce execution")
+		t.Error("Expected no callback after HandlerOnce execution")
 	}
 }
 
@@ -953,12 +1035,14 @@ func TestMultipleSubscribeOnceSameTopic(t *testing.T) {
 	var first int32
 	var second int32
 
-	bus.SubscribeOnce("once.multi.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "once.multi.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&first, 1)
-	})
-	bus.SubscribeOnce("once.multi.test", func(event TestEvent) {
+		return nil
+	}, HandlerOnce())
+	mustSubscribe(t, bus, "once.multi.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&second, 1)
-	})
+		return nil
+	}, HandlerOnce())
 
 	bus.Publish("once.multi.test", TestEvent{ID: "once", Value: 1})
 	bus.Publish("once.multi.test", TestEvent{ID: "again", Value: 2})
@@ -978,15 +1062,17 @@ func TestWildcardSubscription(t *testing.T) {
 	var calls []string
 	var mu sync.Mutex
 
-	bus.SubscribeWithPriority("*", func(event TestEvent) {
+	mustSubscribe(t, bus, "*", func(ctx context.Context, event TestEvent) error {
 		mu.Lock()
 		calls = append(calls, "wildcard:"+event.ID)
 		mu.Unlock()
-	}, PriorityHigh)
-	bus.SubscribeWithHandle("orders.created", func(event TestEvent) {
+		return nil
+	}, HandlerPriority(PriorityHigh))
+	mustSubscribe(t, bus, "orders.created", func(ctx context.Context, event TestEvent) error {
 		mu.Lock()
 		calls = append(calls, "topic:"+event.ID)
 		mu.Unlock()
+		return nil
 	})
 
 	bus.Publish("orders.created", TestEvent{ID: "a", Value: 1})
@@ -1008,11 +1094,10 @@ func TestWildcardSubscribeOnce(t *testing.T) {
 	defer bus.Close()
 
 	var count int32
-	if err := bus.SubscribeOnce("*", func(event TestEvent) {
+	mustSubscribe(t, bus, "*", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&count, 1)
-	}); err != nil {
-		t.Fatalf("Unexpected subscribe error: %v", err)
-	}
+		return nil
+	}, HandlerOnce())
 
 	bus.Publish("first.topic", TestEvent{ID: "first", Value: 1})
 	bus.Publish("second.topic", TestEvent{ID: "second", Value: 2})
@@ -1033,14 +1118,11 @@ func TestSubscribeOnceAsync(t *testing.T) {
 	var processed int32
 	var wg sync.WaitGroup
 
-	err := bus.SubscribeOnceAsync("once.async.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "once.async.test", func(ctx context.Context, event TestEvent) error {
 		atomic.AddInt32(&processed, 1)
 		wg.Done()
-	})
-
-	if err != nil {
-		t.Errorf("Unexpected error in SubscribeOnceAsync: %v", err)
-	}
+		return nil
+	}, HandlerOnce(), HandlerAsync(false))
 
 	// Publish first event (should be processed)
 	wg.Add(1)
@@ -1057,7 +1139,7 @@ func TestSubscribeOnceAsync(t *testing.T) {
 
 	// Verify no callback exists for the topic anymore
 	if bus.HasCallback("once.async.test") {
-		t.Error("Expected no callback after SubscribeOnceAsync execution")
+		t.Error("Expected no callback after once async execution")
 	}
 }
 
@@ -1072,7 +1154,7 @@ func TestHasCallback(t *testing.T) {
 	}
 
 	// Subscribe a handler
-	handle := bus.SubscribeWithHandle("callback.test", func(event TestEvent) {})
+	handle := mustSubscribe(t, bus, "callback.test", discard[TestEvent])
 	defer handle.Unsubscribe()
 
 	// Now should have callback
@@ -1106,9 +1188,9 @@ func TestGetTopics(t *testing.T) {
 	}
 
 	// Subscribe to multiple topics
-	handle1 := bus.SubscribeWithHandle("topic1", func(event TestEvent) {})
-	handle2 := bus.SubscribeWithHandle("topic2", func(event TestEvent) {})
-	handle3 := bus.SubscribeWithHandle("topic3", func(event TestEvent) {})
+	handle1 := mustSubscribe(t, bus, "topic1", discard[TestEvent])
+	handle2 := mustSubscribe(t, bus, "topic2", discard[TestEvent])
+	handle3 := mustSubscribe(t, bus, "topic3", discard[TestEvent])
 
 	defer handle1.Unsubscribe()
 	defer handle2.Unsubscribe()
@@ -1150,23 +1232,21 @@ func TestGetSubscriberCount(t *testing.T) {
 	topic := "subscriber.count.test"
 
 	// Initially no subscribers
-	count := bus.GetSubscriberCount(topic)
-	if count != 0 {
+	if count := bus.GetSubscriberCount(topic); count != 0 {
 		t.Errorf("Expected 0 subscribers initially, got %d", count)
 	}
 
 	// Add subscribers
-	handle1 := bus.SubscribeWithHandle(topic, func(event TestEvent) {})
-	handle2 := bus.SubscribeWithHandle(topic, func(event TestEvent) {})
-	handle3 := bus.SubscribeWithHandle(topic, func(event TestEvent) {})
+	handle1 := mustSubscribe(t, bus, topic, discard[TestEvent])
+	handle2 := mustSubscribe(t, bus, topic, discard[TestEvent])
+	handle3 := mustSubscribe(t, bus, topic, discard[TestEvent])
 
 	defer handle1.Unsubscribe()
 	defer handle2.Unsubscribe()
 	defer handle3.Unsubscribe()
 
 	// Should have 3 subscribers
-	count = bus.GetSubscriberCount(topic)
-	if count != 3 {
+	if count := bus.GetSubscriberCount(topic); count != 3 {
 		t.Errorf("Expected 3 subscribers, got %d", count)
 	}
 
@@ -1174,14 +1254,12 @@ func TestGetSubscriberCount(t *testing.T) {
 	handle1.Unsubscribe()
 
 	// Should have 2 subscribers
-	count = bus.GetSubscriberCount(topic)
-	if count != 2 {
+	if count := bus.GetSubscriberCount(topic); count != 2 {
 		t.Errorf("Expected 2 subscribers after unsubscribe, got %d", count)
 	}
 
 	// Test non-existent topic
-	count = bus.GetSubscriberCount("non.existent.topic")
-	if count != 0 {
+	if count := bus.GetSubscriberCount("non.existent.topic"); count != 0 {
 		t.Errorf("Expected 0 subscribers for non-existent topic, got %d", count)
 	}
 }
@@ -1195,12 +1273,10 @@ func TestEventError(t *testing.T) {
 	}
 
 	errorString := err.Error()
-	expectedSubstring := "event error in topic 'test.topic'"
-	if !contains(errorString, expectedSubstring) {
-		t.Errorf("Expected error string to contain '%s', got '%s'", expectedSubstring, errorString)
+	if !strings.Contains(errorString, "event error in topic 'test.topic'") {
+		t.Errorf("Expected error string to contain the topic, got '%s'", errorString)
 	}
-
-	if !contains(errorString, "test error") {
+	if !strings.Contains(errorString, "test error") {
 		t.Errorf("Expected error string to contain 'test error', got '%s'", errorString)
 	}
 }
@@ -1220,11 +1296,12 @@ func TestAsyncErrorHandling(t *testing.T) {
 	})
 
 	// Subscribe async handler that will panic
-	bus.SubscribeAsync("async.error.test", func(event TestEvent) {
+	mustSubscribe(t, bus, "async.error.test", func(ctx context.Context, event TestEvent) error {
 		if event.Value < 0 {
 			panic("negative value in async handler")
 		}
-	}, false)
+		return nil
+	}, HandlerAsync(false))
 
 	// Publish event that will cause panic
 	wg.Add(1)
@@ -1241,45 +1318,26 @@ func TestClosedBusOperations(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 
 	// Close the bus
-	err := bus.Close()
-	if err != nil {
+	if err := bus.Close(); err != nil {
 		t.Errorf("Unexpected error closing bus: %v", err)
 	}
 
-	// Test Subscribe on closed bus
-	err = bus.Subscribe("closed.test", func(event TestEvent) {})
-	if err == nil {
-		t.Error("Expected error when subscribing to closed bus")
+	// Every subscription shape is rejected with an error and a nil handle.
+	cases := [][]HandlerOption{
+		nil,
+		{HandlerAsync(false)},
+		{HandlerOnce()},
+		{HandlerOnce(), HandlerAsync(false)},
+		{HandlerPriority(PriorityHigh), HandlerSerial()},
 	}
-
-	// Test SubscribeAsync on closed bus
-	err = bus.SubscribeAsync("closed.test", func(event TestEvent) {}, false)
-	if err == nil {
-		t.Error("Expected error when subscribing async to closed bus")
-	}
-
-	// Test SubscribeOnce on closed bus
-	err = bus.SubscribeOnce("closed.test", func(event TestEvent) {})
-	if err == nil {
-		t.Error("Expected error when subscribing once to closed bus")
-	}
-
-	// Test SubscribeOnceAsync on closed bus
-	err = bus.SubscribeOnceAsync("closed.test", func(event TestEvent) {})
-	if err == nil {
-		t.Error("Expected error when subscribing once async to closed bus")
-	}
-
-	// Test doSubscribeWithHandle on closed bus (returns nil)
-	handle := bus.SubscribeWithHandle("closed.test", func(event TestEvent) {})
-	if handle != nil {
-		t.Error("Expected nil handle when subscribing to closed bus")
-	}
-
-	// Test SubscribeAsyncWithHandle on closed bus (returns nil)
-	handle = bus.SubscribeAsyncWithHandle("closed.test", func(event TestEvent) {}, false)
-	if handle != nil {
-		t.Error("Expected nil handle when subscribing async to closed bus")
+	for i, opts := range cases {
+		handle, err := bus.Subscribe("closed.test", discard[TestEvent], opts...)
+		if err == nil {
+			t.Errorf("case %d: expected error when subscribing to closed bus", i)
+		}
+		if handle != nil {
+			t.Errorf("case %d: expected nil handle when subscribing to closed bus", i)
+		}
 	}
 }
 
@@ -1296,29 +1354,12 @@ func TestNilInputsAreIgnoredOrRejected(t *testing.T) {
 	}
 
 	bus.AddMiddleware(nil)
-	if err := bus.Subscribe("nil.fn", nil); err == nil {
+	if _, err := bus.Subscribe("nil.fn", nil); err == nil {
 		t.Fatal("Expected error for nil handler")
 	}
-	if handle := bus.SubscribeWithHandle("nil.fn", nil); handle != nil {
-		t.Fatal("Expected nil handle for nil handler")
-	}
-	if handle := bus.SubscribeWithContext(nil, "nil.ctx", func(event TestEvent) {}); handle == nil {
-		t.Fatal("Expected nil context to default to background context")
+	if handle, err := bus.Subscribe("nil.ctx", discard[TestEvent], HandlerContext(nil)); err != nil || handle == nil {
+		t.Fatalf("Expected nil context to default to background context, got handle=%v err=%v", handle, err)
 	}
 
 	bus.Publish("nil.ctx", TestEvent{ID: "ok", Value: 1})
-}
-
-// Helper function to check if string contains substring
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
-			func() bool {
-				for i := 1; i <= len(s)-len(substr); i++ {
-					if s[i:i+len(substr)] == substr {
-						return true
-					}
-				}
-				return false
-			}())))
 }

--- a/example/advanced_usage.go
+++ b/example/advanced_usage.go
@@ -20,15 +20,6 @@ type UserEvent struct {
 	Data      map[string]interface{} `json:"data"`
 }
 
-// OrderEvent represents an order-related event
-type OrderEvent struct {
-	OrderID   string    `json:"order_id"`
-	UserID    string    `json:"user_id"`
-	Amount    float64   `json:"amount"`
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
 func main() {
 	// Create type-safe event bus
 	eventBus := bus.NewTyped[UserEvent]()
@@ -68,8 +59,8 @@ func main() {
 	fmt.Println("\n=== Example 5: Monitoring and Metrics ===")
 	metricsExample(eventBus)
 
-	// Example 6: Error handling
-	fmt.Println("\n=== Example 6: Error Handling ===")
+	// Example 6: Handler errors
+	fmt.Println("\n=== Example 6: Handler Errors ===")
 	errorHandlingExample(eventBus)
 
 	// Example 7: Timeout publishing
@@ -82,9 +73,13 @@ func main() {
 
 func basicExample(eventBus bus.Bus[UserEvent]) {
 	// Subscribe to user events
-	handle := eventBus.SubscribeWithHandle("user.login", func(event UserEvent) {
+	handle, err := eventBus.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("User login: %s at %s\n", event.UserID, event.Timestamp.Format("15:04:05"))
+		return nil
 	})
+	if err != nil {
+		log.Fatalf("subscribe: %v", err)
+	}
 	defer handle.Unsubscribe()
 
 	// Publish event
@@ -98,19 +93,22 @@ func basicExample(eventBus bus.Bus[UserEvent]) {
 
 func priorityExample(eventBus bus.Bus[UserEvent]) {
 	// High priority handler - security check
-	securityHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+	securityHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("🔒 Security check: User %s performing %s\n", event.UserID, event.Action)
-	}, bus.PriorityCritical)
+		return nil
+	}, bus.HandlerPriority(bus.PriorityCritical))
 
 	// Normal priority handler - logging
-	logHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+	logHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("📝 Logging: User %s performed %s\n", event.UserID, event.Action)
-	}, bus.PriorityNormal)
+		return nil
+	}, bus.HandlerPriority(bus.PriorityNormal))
 
 	// Low priority handler - analytics
-	analyticsHandle := eventBus.SubscribeWithPriority("user.action", func(event UserEvent) {
+	analyticsHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("📊 Analytics: User %s performed %s\n", event.UserID, event.Action)
-	}, bus.PriorityLow)
+		return nil
+	}, bus.HandlerPriority(bus.PriorityLow))
 
 	defer func() {
 		securityHandle.Unsubscribe()
@@ -128,17 +126,19 @@ func priorityExample(eventBus bus.Bus[UserEvent]) {
 
 func filterExample(eventBus bus.Bus[UserEvent]) {
 	// Only process admin user events
-	adminHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEvent) {
+	adminHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("👑 Admin action: %s performed %s\n", event.UserID, event.Action)
-	}, func(topic string, event UserEvent) bool {
+		return nil
+	}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
 		// Assume admin user IDs start with "admin_"
 		return strings.HasPrefix(event.UserID, "admin_")
-	})
+	}))
 
 	// Only process sensitive operations
-	sensitiveHandle := eventBus.SubscribeWithFilter("user.action", func(event UserEvent) {
+	sensitiveHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("⚠️  Sensitive operation alert: %s performed %s\n", event.UserID, event.Action)
-	}, func(topic string, event UserEvent) bool {
+		return nil
+	}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
 		sensitiveActions := []string{"delete", "modify_permissions", "export_data"}
 		for _, action := range sensitiveActions {
 			if event.Action == action {
@@ -146,7 +146,7 @@ func filterExample(eventBus bus.Bus[UserEvent]) {
 			}
 		}
 		return false
-	})
+	}))
 
 	defer func() {
 		adminHandle.Unsubscribe()
@@ -171,9 +171,10 @@ func contextExample(eventBus bus.Bus[UserEvent]) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Subscribe with context
-	handle := eventBus.SubscribeWithContext(ctx, "user.session", func(event UserEvent) {
+	handle, _ := eventBus.Subscribe("user.session", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("Session event: %s - %s\n", event.UserID, event.Action)
-	})
+		return nil
+	}, bus.HandlerContext(ctx))
 	defer handle.Unsubscribe()
 
 	// Publish an event - should be processed
@@ -200,12 +201,14 @@ func contextExample(eventBus bus.Bus[UserEvent]) {
 
 func metricsExample(eventBus bus.Bus[UserEvent]) {
 	// Subscribe multiple handlers
-	handle1 := eventBus.SubscribeWithHandle("metrics.test", func(event UserEvent) {
+	handle1, _ := eventBus.Subscribe("metrics.test", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("Handler 1 processing: %s\n", event.UserID)
+		return nil
 	})
 
-	handle2 := eventBus.SubscribeWithHandle("metrics.test", func(event UserEvent) {
+	handle2, _ := eventBus.Subscribe("metrics.test", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("Handler 2 processing: %s\n", event.UserID)
+		return nil
 	})
 
 	defer func() {
@@ -239,32 +242,36 @@ func metricsExample(eventBus bus.Bus[UserEvent]) {
 }
 
 func errorHandlingExample(eventBus bus.Bus[UserEvent]) {
-	// Subscribe a handler that will panic
-	panicHandle := eventBus.SubscribeWithHandle("user.error", func(event UserEvent) {
-		if event.Action == "panic" {
-			panic("simulating handler crash")
+	// A handler can now report a business failure by returning an error; the
+	// publish call returns the joined failures of the synchronous handlers.
+	errorHandle, _ := eventBus.Subscribe("user.error", func(ctx context.Context, event UserEvent) error {
+		if event.Action == "fail" {
+			return fmt.Errorf("simulated business failure for %s", event.UserID)
 		}
 		fmt.Printf("Normal processing: %s\n", event.UserID)
+		return nil
 	})
-	defer panicHandle.Unsubscribe()
+	defer errorHandle.Unsubscribe()
 
 	// Publish normal event
-	eventBus.Publish("user.error", UserEvent{
+	if err := eventBus.Publish("user.error", UserEvent{
 		UserID:    "user_normal",
 		Action:    "normal",
 		Timestamp: time.Now(),
-	})
+	}); err != nil {
+		fmt.Printf("Unexpected publish error: %v\n", err)
+	}
 
-	// Publish event that will cause panic
-	fmt.Println("Publishing event that will cause panic...")
-	eventBus.Publish("user.error", UserEvent{
-		UserID:    "user_panic",
-		Action:    "panic",
+	// Publish event whose handler fails; the error comes back from Publish
+	// and is also reported to the ErrorHandler.
+	fmt.Println("Publishing event whose handler fails...")
+	if err := eventBus.Publish("user.error", UserEvent{
+		UserID:    "user_fail",
+		Action:    "fail",
 		Timestamp: time.Now(),
-	})
-
-	// Wait for processing to complete
-	eventBus.WaitAsync()
+	}); err != nil {
+		fmt.Printf("Publish returned the handler failure: %v\n", err)
+	}
 
 	// Check error metrics
 	metrics := eventBus.GetMetrics()
@@ -273,11 +280,19 @@ func errorHandlingExample(eventBus bus.Bus[UserEvent]) {
 }
 
 func timeoutExample(eventBus bus.Bus[UserEvent]) {
-	// Subscribe an async slow handler
-	eventBus.SubscribeAsync("user.slow", func(event UserEvent) {
-		time.Sleep(2 * time.Second) // Simulate slow processing
-		fmt.Printf("Slow processing completed: %s\n", event.UserID)
-	}, false)
+	// Subscribe a slow handler with a per-handler timeout. The handler's
+	// context is canceled when the timeout elapses, so it can stop early.
+	handle, _ := eventBus.Subscribe("user.slow", func(ctx context.Context, event UserEvent) error {
+		select {
+		case <-time.After(2 * time.Second): // Simulate slow processing
+			fmt.Printf("Slow processing completed: %s\n", event.UserID)
+			return nil
+		case <-ctx.Done():
+			fmt.Printf("Slow processing canceled for %s: %v\n", event.UserID, ctx.Err())
+			return ctx.Err()
+		}
+	}, bus.HandlerTimeout(500*time.Millisecond))
+	defer handle.Unsubscribe()
 
 	// Use timeout publishing
 	err := eventBus.PublishWithTimeout("user.slow", UserEvent{
@@ -289,4 +304,5 @@ func timeoutExample(eventBus bus.Bus[UserEvent]) {
 	if err != nil {
 		fmt.Printf("Publish timeout: %v\n", err)
 	}
+	eventBus.WaitAsync()
 }

--- a/example/basic_example.go
+++ b/example/basic_example.go
@@ -55,15 +55,14 @@ func basicExample() {
 	defer eventBus.Close()
 
 	// Subscribe to an event
-	eventBus.Subscribe("user.login", func(data interface{}) {
+	eventBus.Subscribe("user.login", func(ctx context.Context, data any) error {
 		fmt.Printf("User logged in: %v\n", data)
+		return nil
 	})
 
 	// Publish an event
 	eventBus.Publish("user.login", "john@example.com")
 
-	// Wait for async processing
-	time.Sleep(50 * time.Millisecond)
 	fmt.Println()
 }
 
@@ -75,10 +74,15 @@ func typedExample() {
 	defer eventBus.Close()
 
 	// Subscribe with typed handler
-	handle := eventBus.SubscribeWithHandle("app.event", func(event Event) {
+	handle, err := eventBus.Subscribe("app.event", func(ctx context.Context, event Event) error {
 		fmt.Printf("Received event: ID=%s, Message=%s, Time=%s\n",
 			event.ID, event.Message, event.Time.Format("15:04:05"))
+		return nil
 	})
+	if err != nil {
+		fmt.Println("subscribe failed:", err)
+		return
+	}
 	defer handle.Unsubscribe()
 
 	// Publish typed event
@@ -88,7 +92,6 @@ func typedExample() {
 		Time:    time.Now(),
 	})
 
-	time.Sleep(50 * time.Millisecond)
 	fmt.Println()
 }
 
@@ -99,16 +102,18 @@ func asyncExample() {
 	defer eventBus.Close()
 
 	// Sync handler
-	eventBus.Subscribe("user.action", func(action UserAction) {
+	eventBus.Subscribe("user.action", func(ctx context.Context, action UserAction) error {
 		fmt.Printf("Sync handler: User %s performed %s\n", action.UserID, action.Action)
+		return nil
 	})
 
 	// Async handler
-	eventBus.SubscribeAsync("user.action", func(action UserAction) {
+	eventBus.Subscribe("user.action", func(ctx context.Context, action UserAction) error {
 		time.Sleep(100 * time.Millisecond) // Simulate slow processing
 		fmt.Printf("Async handler: User %s performed %s (processed after delay)\n",
 			action.UserID, action.Action)
-	}, false)
+		return nil
+	}, bus.HandlerAsync(false))
 
 	// Publish event
 	eventBus.Publish("user.action", UserAction{
@@ -129,11 +134,17 @@ func contextExample() {
 
 	// Create cancellable context
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Subscribe with context
-	handle := eventBus.SubscribeWithContext(ctx, "system.message", func(event Event) {
+	handle, err := eventBus.Subscribe("system.message", func(ctx context.Context, event Event) error {
 		fmt.Printf("Context handler: %s\n", event.Message)
-	})
+		return nil
+	}, bus.HandlerContext(ctx))
+	if err != nil {
+		fmt.Println("subscribe failed:", err)
+		return
+	}
 	defer handle.Unsubscribe()
 
 	// Publish event - should be processed
@@ -154,7 +165,6 @@ func contextExample() {
 		Time:    time.Now(),
 	})
 
-	time.Sleep(50 * time.Millisecond)
 	fmt.Println()
 }
 
@@ -165,22 +175,24 @@ func multipleSubscribersExample() {
 	defer eventBus.Close()
 
 	// Multiple handlers for the same event
-	eventBus.Subscribe("notification", func(data interface{}) {
+	eventBus.Subscribe("notification", func(ctx context.Context, data any) error {
 		fmt.Printf("Email handler: Sending email for %v\n", data)
+		return nil
 	})
 
-	eventBus.Subscribe("notification", func(data interface{}) {
+	eventBus.Subscribe("notification", func(ctx context.Context, data any) error {
 		fmt.Printf("SMS handler: Sending SMS for %v\n", data)
+		return nil
 	})
 
-	eventBus.Subscribe("notification", func(data interface{}) {
+	eventBus.Subscribe("notification", func(ctx context.Context, data any) error {
 		fmt.Printf("Push handler: Sending push notification for %v\n", data)
+		return nil
 	})
 
 	// Publish event to all subscribers
 	eventBus.Publish("notification", "New order received")
 
-	time.Sleep(50 * time.Millisecond)
 	fmt.Println()
 }
 
@@ -191,23 +203,22 @@ func onceExample() {
 	defer eventBus.Close()
 
 	// Subscribe once - handler will be removed after first execution
-	eventBus.SubscribeOnce("init.complete", func(data interface{}) {
+	eventBus.Subscribe("init.complete", func(ctx context.Context, data any) error {
 		fmt.Printf("Initialization completed: %v\n", data)
-	})
+		return nil
+	}, bus.HandlerOnce())
 
 	// Check if callback exists
 	fmt.Printf("Has init.complete handler: %v\n", eventBus.HasCallback("init.complete"))
 
 	// Publish first time - handler executes
 	eventBus.Publish("init.complete", "Application ready")
-	time.Sleep(50 * time.Millisecond)
 
 	// Check again - handler should be removed
 	fmt.Printf("Has init.complete handler after first publish: %v\n", eventBus.HasCallback("init.complete"))
 
 	// Publish second time - no handler should execute
 	eventBus.Publish("init.complete", "Second init (should be ignored)")
-	time.Sleep(50 * time.Millisecond)
 
 	fmt.Println()
 }

--- a/example/e_commerce_example.go
+++ b/example/e_commerce_example.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -81,7 +82,7 @@ func main() {
 
 func processOrderWorkflow(orderBus bus.Bus[Order], paymentBus bus.Bus[Payment], inventoryBus bus.Bus[Inventory]) {
 	// Order Service - handles order lifecycle
-	orderCreatedHandle := orderBus.SubscribeWithPriority("order.created", func(order Order) {
+	orderCreatedHandle, _ := orderBus.Subscribe("order.created", func(ctx context.Context, order Order) error {
 		fmt.Printf("📦 [ORDER-SERVICE] Order created: %s for user %s (%.2f)\n",
 			order.ID, order.UserID, order.Amount)
 
@@ -101,10 +102,11 @@ func processOrderWorkflow(orderBus bus.Bus[Order], paymentBus bus.Bus[Payment], 
 			Method:  "credit_card",
 			Status:  "pending",
 		})
-	}, bus.PriorityCritical)
+		return nil
+	}, bus.HandlerPriority(bus.PriorityCritical))
 
 	// Inventory Service - manages stock
-	inventoryReserveHandle := inventoryBus.SubscribeWithHandle("inventory.reserve", func(inv Inventory) {
+	inventoryReserveHandle, _ := inventoryBus.Subscribe("inventory.reserve", func(ctx context.Context, inv Inventory) error {
 		fmt.Printf("📦 [INVENTORY-SERVICE] Reserving %d units of product %s\n",
 			inv.Quantity, inv.ProductID)
 
@@ -112,15 +114,17 @@ func processOrderWorkflow(orderBus bus.Bus[Order], paymentBus bus.Bus[Payment], 
 		time.Sleep(50 * time.Millisecond)
 		fmt.Printf("✅ [INVENTORY-SERVICE] Reserved %d units of product %s\n",
 			inv.Quantity, inv.ProductID)
+		return nil
 	})
 
-	inventoryReleaseHandle := inventoryBus.SubscribeWithHandle("inventory.release", func(inv Inventory) {
+	inventoryReleaseHandle, _ := inventoryBus.Subscribe("inventory.release", func(ctx context.Context, inv Inventory) error {
 		fmt.Printf("🔄 [INVENTORY-SERVICE] Releasing %d units of product %s\n",
 			inv.Quantity, inv.ProductID)
+		return nil
 	})
 
 	// Payment Service - processes payments
-	paymentProcessHandle := paymentBus.SubscribeWithHandle("payment.process", func(payment Payment) {
+	paymentProcessHandle, _ := paymentBus.Subscribe("payment.process", func(ctx context.Context, payment Payment) error {
 		fmt.Printf("💳 [PAYMENT-SERVICE] Processing payment for order %s (%.2f)\n",
 			payment.OrderID, payment.Amount)
 
@@ -145,10 +149,11 @@ func processOrderWorkflow(orderBus bus.Bus[Order], paymentBus bus.Bus[Payment], 
 				Status:  "completed",
 			})
 		}
+		return nil
 	})
 
 	// Payment Success Handler
-	paymentSuccessHandle := paymentBus.SubscribeWithHandle("payment.succeeded", func(payment Payment) {
+	paymentSuccessHandle, _ := paymentBus.Subscribe("payment.succeeded", func(ctx context.Context, payment Payment) error {
 		fmt.Printf("✅ [PAYMENT-SERVICE] Payment succeeded for order %s\n", payment.OrderID)
 
 		// Update order status to confirmed
@@ -156,10 +161,11 @@ func processOrderWorkflow(orderBus bus.Bus[Order], paymentBus bus.Bus[Payment], 
 			ID:     payment.OrderID,
 			Status: "confirmed",
 		})
+		return nil
 	})
 
 	// Payment Failure Handler
-	paymentFailureHandle := paymentBus.SubscribeWithHandle("payment.failed", func(payment Payment) {
+	paymentFailureHandle, _ := paymentBus.Subscribe("payment.failed", func(ctx context.Context, payment Payment) error {
 		fmt.Printf("❌ [PAYMENT-SERVICE] Payment failed for order %s\n", payment.OrderID)
 
 		// Cancel order and release inventory
@@ -167,18 +173,20 @@ func processOrderWorkflow(orderBus bus.Bus[Order], paymentBus bus.Bus[Payment], 
 			ID:     payment.OrderID,
 			Status: "cancelled",
 		})
+		return nil
 	})
 
 	// Order Confirmed Handler
-	orderConfirmedHandle := orderBus.SubscribeWithHandle("order.confirmed", func(order Order) {
+	orderConfirmedHandle, _ := orderBus.Subscribe("order.confirmed", func(ctx context.Context, order Order) error {
 		fmt.Printf("🎉 [ORDER-SERVICE] Order confirmed: %s\n", order.ID)
 
 		// Trigger shipping process
 		fmt.Printf("📮 [SHIPPING-SERVICE] Shipping initiated for order %s\n", order.ID)
+		return nil
 	})
 
 	// Order Cancelled Handler
-	orderCancelledHandle := orderBus.SubscribeWithHandle("order.cancelled", func(order Order) {
+	orderCancelledHandle, _ := orderBus.Subscribe("order.cancelled", func(ctx context.Context, order Order) error {
 		fmt.Printf("❌ [ORDER-SERVICE] Order cancelled: %s\n", order.ID)
 
 		// Release reserved inventory (simulation)
@@ -187,17 +195,20 @@ func processOrderWorkflow(orderBus bus.Bus[Order], paymentBus bus.Bus[Payment], 
 			Quantity:  1,
 			Operation: "release",
 		})
+		return nil
 	})
 
 	// Notification Service - sends notifications (low priority)
-	notificationHandle := orderBus.SubscribeWithPriority("order.confirmed", func(order Order) {
+	notificationHandle, _ := orderBus.Subscribe("order.confirmed", func(ctx context.Context, order Order) error {
 		fmt.Printf("📧 [NOTIFICATION-SERVICE] Sending confirmation email for order %s\n", order.ID)
-	}, bus.PriorityLow)
+		return nil
+	}, bus.HandlerPriority(bus.PriorityLow))
 
 	// Analytics Service - tracks metrics (lowest priority)
-	analyticsHandle := orderBus.SubscribeWithPriority("order.created", func(order Order) {
+	analyticsHandle, _ := orderBus.Subscribe("order.created", func(ctx context.Context, order Order) error {
 		fmt.Printf("📊 [ANALYTICS-SERVICE] Recording order metrics for %s\n", order.ID)
-	}, bus.PriorityLow)
+		return nil
+	}, bus.HandlerPriority(bus.PriorityLow))
 
 	defer func() {
 		orderCreatedHandle.Unsubscribe()

--- a/example/middleware_example.go
+++ b/example/middleware_example.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -55,12 +56,14 @@ func main() {
 	})
 
 	// Subscribe to events
-	handle1 := eventBus.SubscribeWithHandle("user.created", func(event Event) {
+	handle1, _ := eventBus.Subscribe("user.created", func(ctx context.Context, event Event) error {
 		fmt.Printf("User created handler: %s - %s\n", event.ID, event.Payload)
+		return nil
 	})
 
-	handle2 := eventBus.SubscribeWithHandle("rate.limited", func(event Event) {
+	handle2, _ := eventBus.Subscribe("rate.limited", func(ctx context.Context, event Event) error {
 		fmt.Printf("Rate limited handler: %s - %s\n", event.ID, event.Payload)
+		return nil
 	})
 
 	defer func() {

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package bus_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -20,9 +21,14 @@ func Example() {
 	b := bus.NewTyped[UserEvent]()
 	defer b.Close()
 
-	handle := b.SubscribeWithHandle("user.login", func(event UserEvent) {
+	handle, err := b.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
 		fmt.Printf("%s performed %s\n", event.UserID, event.Action)
+		return nil
 	})
+	if err != nil {
+		fmt.Println("subscribe failed:", err)
+		return
+	}
 	defer handle.Unsubscribe()
 
 	b.Publish("user.login", UserEvent{UserID: "u-1", Action: "login"})
@@ -33,19 +39,20 @@ func Example() {
 
 // Handlers run from the highest priority to the lowest. Handlers registered at
 // the same priority keep their registration order.
-func ExampleEventBus_SubscribeWithPriority() {
+func ExampleHandlerPriority() {
 	b := bus.NewTyped[string]()
 	defer b.Close()
 
-	b.SubscribeWithPriority("order.placed", func(string) {
-		fmt.Println("3. analytics")
-	}, bus.PriorityLow)
-	b.SubscribeWithPriority("order.placed", func(string) {
-		fmt.Println("1. fraud check")
-	}, bus.PriorityCritical)
-	b.SubscribeWithPriority("order.placed", func(string) {
-		fmt.Println("2. fulfilment")
-	}, bus.PriorityNormal)
+	say := func(line string) bus.Handler[string] {
+		return func(ctx context.Context, event string) error {
+			fmt.Println(line)
+			return nil
+		}
+	}
+
+	b.Subscribe("order.placed", say("3. analytics"), bus.HandlerPriority(bus.PriorityLow))
+	b.Subscribe("order.placed", say("1. fraud check"), bus.HandlerPriority(bus.PriorityCritical))
+	b.Subscribe("order.placed", say("2. fulfilment"), bus.HandlerPriority(bus.PriorityNormal))
 
 	b.Publish("order.placed", "o-1")
 
@@ -56,15 +63,16 @@ func ExampleEventBus_SubscribeWithPriority() {
 }
 
 // A filter decides per event whether its handler runs at all.
-func ExampleEventBus_SubscribeWithFilter() {
+func ExampleHandlerFilter() {
 	b := bus.NewTyped[UserEvent]()
 	defer b.Close()
 
-	b.SubscribeWithFilter("user.action", func(event UserEvent) {
+	b.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
 		fmt.Println("admin action:", event.Action)
-	}, func(topic string, event UserEvent) bool {
+		return nil
+	}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
 		return strings.HasPrefix(event.UserID, "admin-")
-	})
+	}))
 
 	b.Publish("user.action", UserEvent{UserID: "u-1", Action: "read"})
 	b.Publish("user.action", UserEvent{UserID: "admin-1", Action: "delete"})
@@ -73,14 +81,17 @@ func ExampleEventBus_SubscribeWithFilter() {
 	// admin action: delete
 }
 
-// SubscribeWithOptions is the extensible subscription path. It is the only
-// helper that reports why a subscription was rejected.
-func ExampleEventBus_SubscribeWithOptions() {
+// Options compose: a single Subscribe call configures priority, timeout,
+// panic policy and concurrency.
+func ExampleEventBus_Subscribe() {
 	b := bus.NewTyped[string]()
 	defer b.Close()
 
-	handle, err := b.SubscribeWithOptions("payment.validate",
-		func(id string) { fmt.Println("validating", id) },
+	handle, err := b.Subscribe("payment.validate",
+		func(ctx context.Context, id string) error {
+			fmt.Println("validating", id)
+			return nil
+		},
 		bus.HandlerPriority(bus.PriorityHigh),
 		bus.HandlerTimeout(2*time.Second),
 		bus.HandlerRecoverPolicy(bus.RecoverAndStop),
@@ -98,6 +109,31 @@ func ExampleEventBus_SubscribeWithOptions() {
 	// validating p-1
 }
 
+// A handler error does not stop dispatch: later handlers still run, and the
+// publish call returns the joined failures of the synchronous handlers.
+func ExampleEventBus_Publish() {
+	b := bus.NewTyped[string]()
+	defer b.Close()
+	// The default logger reports handler failures on stdout; silence it here
+	// so the example output stays deterministic.
+	b.SetLogger(bus.NewNoOpLogger())
+
+	b.Subscribe("job.run", func(ctx context.Context, id string) error {
+		return errors.New("disk full")
+	}, bus.HandlerPriority(bus.PriorityHigh))
+	b.Subscribe("job.run", func(ctx context.Context, id string) error {
+		fmt.Println("second handler still runs")
+		return nil
+	})
+
+	err := b.Publish("job.run", "j-1")
+	fmt.Println("err:", err)
+
+	// Output:
+	// second handler still runs
+	// err: disk full
+}
+
 // Middleware wraps the whole dispatch. Calling next runs the remaining
 // middleware and then the handlers; not calling it intercepts the event.
 func ExampleEventBus_AddMiddleware() {
@@ -111,8 +147,9 @@ func ExampleEventBus_AddMiddleware() {
 		return nil
 	})
 
-	_ = b.Subscribe("job.run", func(id string) {
+	b.Subscribe("job.run", func(ctx context.Context, id string) error {
 		fmt.Println("handling", id)
+		return nil
 	})
 	b.Publish("job.run", "j-1")
 
@@ -128,11 +165,13 @@ func ExampleEventBus_Subscribe_wildcard() {
 	b := bus.NewTyped[string]()
 	defer b.Close()
 
-	_ = b.Subscribe("user.created", func(payload string) {
+	b.Subscribe("user.created", func(ctx context.Context, payload string) error {
 		fmt.Println("welcome:", payload)
+		return nil
 	})
-	_ = b.Subscribe("*", func(payload string) {
+	b.Subscribe("*", func(ctx context.Context, payload string) error {
 		fmt.Println("audit:", payload)
+		return nil
 	})
 
 	b.Publish("user.created", "u-1")
@@ -142,8 +181,8 @@ func ExampleEventBus_Subscribe_wildcard() {
 	// audit: u-1
 }
 
-// Publish discards errors. Use PublishWithContext when cancellation, timeout or
-// closed-bus errors matter.
+// Canceling the publish context aborts dispatch; a closed bus rejects the
+// publish outright.
 func ExampleEventBus_PublishWithContext() {
 	b := bus.NewTyped[string]()
 	b.Close()
@@ -159,7 +198,7 @@ func ExampleEventBus_GetMetrics() {
 	b := bus.NewTyped[string]()
 	defer b.Close()
 
-	_ = b.Subscribe("job.run", func(string) {})
+	b.Subscribe("job.run", func(ctx context.Context, id string) error { return nil })
 	b.Publish("job.run", "j-1")
 	b.Publish("job.run", "j-2")
 
@@ -170,14 +209,15 @@ func ExampleEventBus_GetMetrics() {
 	// 2 2 0 1
 }
 
-// Subscribe helpers that return only a handle yield nil when the subscription
-// is rejected. The returned handle stays safe to use, so a deferred
-// Unsubscribe never panics.
+// Ignoring the error from Subscribe leaves a nil handle. The nil handle stays
+// safe to use, so a deferred Unsubscribe never panics.
 func ExampleHandle_Unsubscribe_nilHandle() {
 	b := bus.NewTyped[string]()
 	b.Close()
 
-	handle := b.SubscribeWithHandle("user.created", func(string) {})
+	handle, _ := b.Subscribe("user.created", func(ctx context.Context, event string) error {
+		return nil
+	})
 	fmt.Println("active:", handle.IsActive())
 	fmt.Println("err:", handle.Unsubscribe())
 

--- a/handle.go
+++ b/handle.go
@@ -9,20 +9,16 @@ import (
 
 // Handle represents a subscription handle that can be used to unsubscribe
 type Handle[T any] struct {
-	bus      *EventBus[T]
-	topic    string
-	handler  *eventHandler[T]
-	priority Priority
-	filter   EventFilter[T]
-	ctx      context.Context
-	mu       sync.Mutex
+	bus     *EventBus[T]
+	topic   string
+	handler *eventHandler[T]
+	mu      sync.Mutex
 }
 
 // Unsubscribe removes this specific subscription.
 //
-// A nil handle is reported as an error rather than a panic. Subscribe helpers
-// that return only a handle yield nil when the subscription is rejected (nil
-// callback, or a closed bus), so a deferred Unsubscribe must stay safe.
+// A nil handle is reported as an error rather than a panic, so ignoring the
+// error from Subscribe and deferring Unsubscribe stays safe.
 func (h *Handle[T]) Unsubscribe() error {
 	if h == nil {
 		return fmt.Errorf("handle is nil: the subscription was never created")
@@ -62,7 +58,7 @@ func (h *Handle[T]) IsActive() bool {
 type eventHandler[T any] struct {
 	id             string
 	topic          string
-	callBack       func(T)
+	callBack       Handler[T]
 	flagOnce       bool
 	async          bool
 	transactional  bool

--- a/handle_test.go
+++ b/handle_test.go
@@ -5,23 +5,26 @@ import (
 	"testing"
 )
 
-// The Subscribe helpers that return only a handle yield nil when the
-// subscription is rejected. A deferred Unsubscribe on that nil handle must
-// report an error instead of panicking.
+// Ignoring the error from Subscribe leaves a nil handle. A deferred
+// Unsubscribe on that nil handle must report an error instead of panicking.
 func TestNilHandleIsSafe(t *testing.T) {
 	closed := NewTyped[string]()
 	if err := closed.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
+	subscribe := func(b *EventBus[string], fn Handler[string], opts ...HandlerOption) *Handle[string] {
+		handle, _ := b.Subscribe("topic", fn, opts...)
+		return handle
+	}
+
 	cases := map[string]*Handle[string]{
-		"closed bus, SubscribeWithHandle":   closed.SubscribeWithHandle("topic", func(string) {}),
-		"closed bus, SubscribeWithPriority": closed.SubscribeWithPriority("topic", func(string) {}, PriorityHigh),
-		"closed bus, SubscribeWithFilter": closed.SubscribeWithFilter("topic", func(string) {}, func(string, string) bool {
-			return true
-		}),
-		"closed bus, SubscribeWithContext": closed.SubscribeWithContext(context.Background(), "topic", func(string) {}),
-		"nil callback":                     NewTyped[string]().SubscribeWithHandle("topic", nil),
+		"closed bus":               subscribe(closed, discard[string]),
+		"closed bus with priority": subscribe(closed, discard[string], HandlerPriority(PriorityHigh)),
+		"closed bus with context":  subscribe(closed, discard[string], HandlerContext(context.Background())),
+		"nil callback":             subscribe(NewTyped[string](), nil),
+		"filter type mismatch": subscribe(NewTyped[string](), discard[string],
+			HandlerFilter(func(topic string, event int) bool { return true })),
 	}
 
 	for name, handle := range cases {
@@ -50,10 +53,7 @@ func TestHandleUnsubscribeIsIdempotent(t *testing.T) {
 	b := NewTyped[string]()
 	defer b.Close()
 
-	handle := b.SubscribeWithHandle("topic", func(string) {})
-	if handle == nil {
-		t.Fatal("expected a handle")
-	}
+	handle := mustSubscribe(t, b, "topic", discard[string])
 	if !handle.IsActive() {
 		t.Fatal("fresh handle should be active")
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -7,25 +7,12 @@ import (
 
 // BusSubscriber defines subscription-related bus behavior
 type BusSubscriber[T any] interface {
-	Subscribe(topic string, fn func(T)) error
-	SubscribeAsync(topic string, fn func(T), transactional bool) error
-	SubscribeOnce(topic string, fn func(T)) error
-	SubscribeOnceAsync(topic string, fn func(T)) error
-	SubscribeWithHandle(topic string, fn func(T)) *Handle[T]
-	SubscribeAsyncWithHandle(topic string, fn func(T), transactional bool) *Handle[T]
-	SubscribeWithPriority(topic string, fn func(T), priority Priority) *Handle[T]
-	SubscribeWithFilter(topic string, fn func(T), filter EventFilter[T]) *Handle[T]
-	SubscribeWithContext(ctx context.Context, topic string, fn func(T)) *Handle[T]
-}
-
-// ControlledSubscriber defines optional handler-level execution control behavior.
-type ControlledSubscriber[T any] interface {
-	SubscribeWithOptions(topic string, fn func(T), options ...HandlerOption) (*Handle[T], error)
+	Subscribe(topic string, fn Handler[T], options ...HandlerOption) (*Handle[T], error)
 }
 
 // BusPublisher defines publishing-related bus behavior
 type BusPublisher[T any] interface {
-	Publish(topic string, event T)
+	Publish(topic string, event T) error
 	PublishWithContext(ctx context.Context, topic string, event T) error
 	PublishWithTimeout(topic string, event T, timeout time.Duration) error
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -127,9 +128,7 @@ func TestEventBusWithLogger(t *testing.T) {
 	}
 
 	// Test subscription logging
-	handle := eventBus.SubscribeWithHandle("test.topic", func(data string) {
-		// Handler logic
-	})
+	handle := mustSubscribe(t, eventBus, "test.topic", discard[string])
 
 	logs := testLogger.GetLogs()
 	if !strings.Contains(logs, "Handler subscribed to topic 'test.topic'") {
@@ -169,7 +168,7 @@ func TestEventBusLoggerWithPanic(t *testing.T) {
 	eventBus.SetLogger(testLogger)
 
 	// Subscribe a handler that panics
-	eventBus.Subscribe("panic.topic", func(data string) {
+	mustSubscribe(t, eventBus, "panic.topic", func(ctx context.Context, data string) error {
 		panic("test panic")
 	})
 
@@ -182,6 +181,26 @@ func TestEventBusLoggerWithPanic(t *testing.T) {
 	}
 }
 
+func TestEventBusLoggerWithHandlerError(t *testing.T) {
+	testLogger := NewTestLogger()
+	eventBus := NewTyped[string]()
+	eventBus.SetLogger(testLogger)
+
+	mustSubscribe(t, eventBus, "error.topic", func(ctx context.Context, data string) error {
+		return fmt.Errorf("business failure")
+	})
+
+	_ = eventBus.Publish("error.topic", "test data")
+
+	logs := testLogger.GetLogs()
+	if !strings.Contains(logs, "Handler failed for topic 'error.topic'") {
+		t.Errorf("Expected handler failure log, got: %s", logs)
+	}
+	if strings.Contains(logs, "Handler panic") {
+		t.Errorf("A returned error must not be logged as a panic, got: %s", logs)
+	}
+}
+
 func TestEventBusLoggerLevels(t *testing.T) {
 	testLogger := NewTestLogger()
 	eventBus := NewTyped[string]()
@@ -191,7 +210,7 @@ func TestEventBusLoggerLevels(t *testing.T) {
 	testLogger.SetLevel(LogLevelError)
 
 	// Subscribe and publish
-	eventBus.Subscribe("test.topic", func(data string) {})
+	mustSubscribe(t, eventBus, "test.topic", discard[string])
 	eventBus.Publish("test.topic", "test data")
 
 	logs := testLogger.GetLogs()
@@ -202,7 +221,7 @@ func TestEventBusLoggerLevels(t *testing.T) {
 
 	// Test with panic (should show error)
 	testLogger.Clear()
-	eventBus.Subscribe("panic.topic", func(data string) {
+	mustSubscribe(t, eventBus, "panic.topic", func(ctx context.Context, data string) error {
 		panic("test panic")
 	})
 	eventBus.Publish("panic.topic", "test data")
@@ -218,11 +237,11 @@ func TestEventBusWithNoOpLogger(t *testing.T) {
 	eventBus.SetLogger(NewNoOpLogger())
 
 	// Should not panic with no-op logger
-	eventBus.Subscribe("test.topic", func(data string) {})
+	mustSubscribe(t, eventBus, "test.topic", discard[string])
 	eventBus.Publish("test.topic", "test data")
 
 	// Subscribe a handler that panics
-	eventBus.Subscribe("panic.topic", func(data string) {
+	mustSubscribe(t, eventBus, "panic.topic", func(ctx context.Context, data string) error {
 		panic("test panic")
 	})
 	eventBus.Publish("panic.topic", "test data")
@@ -241,8 +260,9 @@ func TestLoggerConcurrency(t *testing.T) {
 			defer func() { done <- true }()
 
 			topic := "concurrent.topic"
-			eventBus.Subscribe(topic, func(data int) {
+			_, _ = eventBus.Subscribe(topic, func(ctx context.Context, data int) error {
 				time.Sleep(1 * time.Millisecond)
+				return nil
 			})
 
 			for j := 0; j < 5; j++ {
@@ -267,9 +287,7 @@ func BenchmarkEventBusWithLogger(b *testing.B) {
 	eventBus := NewTyped[string]()
 	eventBus.SetLogger(NewDefaultLogger())
 
-	eventBus.Subscribe("bench.topic", func(data string) {
-		// Simple handler
-	})
+	mustSubscribe(b, eventBus, "bench.topic", discard[string])
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -281,9 +299,7 @@ func BenchmarkEventBusWithNoOpLogger(b *testing.B) {
 	eventBus := NewTyped[string]()
 	eventBus.SetLogger(NewNoOpLogger())
 
-	eventBus.Subscribe("bench.topic", func(data string) {
-		// Simple handler
-	})
+	mustSubscribe(b, eventBus, "bench.topic", discard[string])
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,6 +1,7 @@
 package bus
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -50,9 +51,7 @@ func TestCustomMetricsImplementation(t *testing.T) {
 	defer bus.Close()
 
 	// Subscribe to an event
-	handle := bus.SubscribeWithHandle("test.topic", func(event any) {
-		// Normal processing
-	})
+	handle := mustSubscribe(t, bus, "test.topic", discard[any])
 	defer handle.Unsubscribe()
 
 	// Check subscriber count
@@ -118,9 +117,7 @@ func TestWithOptions(t *testing.T) {
 	defer bus.Close()
 
 	// Test publish and subscribe
-	bus.Subscribe("test.options", func(event any) {
-		// Normal processing
-	})
+	mustSubscribe(t, bus, "test.options", discard[any])
 
 	bus.Publish("test.options", "test event")
 	bus.WaitAsync()
@@ -138,6 +135,25 @@ func TestWithOptions(t *testing.T) {
 	metricsFromBus := bus.GetMetrics()
 	if metricsFromBus != customMetrics {
 		t.Errorf("Expected metrics from bus to be our custom metrics instance")
+	}
+}
+
+func TestHandlerErrorRecordedInDetailedMetrics(t *testing.T) {
+	bus := NewTyped[string]()
+	defer bus.Close()
+
+	mustSubscribe(t, bus, "orders.created", func(ctx context.Context, event string) error {
+		return context.DeadlineExceeded
+	})
+	_ = bus.Publish("orders.created", "o-1")
+
+	detailed, ok := bus.GetMetrics().(*DefaultMetrics)
+	if !ok {
+		t.Fatal("Expected the default metrics implementation")
+	}
+	stats := detailed.GetTopicStats()["orders.created"]
+	if stats.FailedEvents != 1 {
+		t.Fatalf("Expected the returned handler error to count as a failed delivery, got %d", stats.FailedEvents)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -24,9 +24,13 @@ type handlerOptions struct {
 	timeout        time.Duration
 	recoverPolicy  RecoverPolicy
 	maxConcurrency int
+	// filter holds an EventFilter[T]. The option constructor is generic while
+	// HandlerOption is not, so the value is carried as any and re-typed by
+	// Subscribe, which reports a mismatch as an error.
+	filter any
 }
 
-// HandlerOption configures a subscription created with SubscribeWithOptions.
+// HandlerOption configures a subscription created with Subscribe.
 type HandlerOption func(*handlerOptions)
 
 // HandlerPriority sets the handler priority.
@@ -37,6 +41,7 @@ func HandlerPriority(priority Priority) HandlerOption {
 }
 
 // HandlerContext sets a context that can disable the handler when canceled.
+// Asynchronous handlers also receive this context while running.
 func HandlerContext(ctx context.Context) HandlerOption {
 	return func(opts *handlerOptions) {
 		opts.ctx = ctx
@@ -58,7 +63,20 @@ func HandlerOnce() HandlerOption {
 	}
 }
 
-// HandlerTimeout bounds how long PublishWithContext waits for this handler.
+// HandlerFilter runs the handler only for events accepted by the filter. The
+// filter's event type must match the bus event type; Subscribe reports a
+// mismatch as an error.
+func HandlerFilter[T any](filter EventFilter[T]) HandlerOption {
+	return func(opts *handlerOptions) {
+		if filter == nil {
+			return
+		}
+		opts.filter = filter
+	}
+}
+
+// HandlerTimeout bounds how long a publish call waits for this handler. The
+// handler's context is canceled when the timeout elapses.
 func HandlerTimeout(timeout time.Duration) HandlerOption {
 	return func(opts *handlerOptions) {
 		opts.timeout = timeout

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"context"
 	"testing"
 
 	client "github.com/prometheus/client_golang/prometheus"
@@ -19,10 +20,14 @@ func TestMetricsImplementsBusMetrics(t *testing.T) {
 	eventBus := bus.NewTyped[string](bus.WithMetrics[string](metrics))
 	defer eventBus.Close()
 
-	if _, err := eventBus.SubscribeWithOptions("topic", func(event string) {}, bus.HandlerSerial()); err != nil {
+	if _, err := eventBus.Subscribe("topic", func(ctx context.Context, event string) error {
+		return nil
+	}, bus.HandlerSerial()); err != nil {
 		t.Fatalf("Unexpected subscribe error: %v", err)
 	}
-	eventBus.Publish("topic", "event")
+	if err := eventBus.Publish("topic", "event"); err != nil {
+		t.Fatalf("Unexpected publish error: %v", err)
+	}
 
 	published, processed, failed, subscribers := metrics.GetStats()
 	if published != 1 || processed != 1 || failed != 0 || subscribers != 1 {

--- a/types.go
+++ b/types.go
@@ -1,6 +1,9 @@
 package bus
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // Priority defines the execution priority of handlers
 type Priority int
@@ -11,6 +14,20 @@ const (
 	PriorityHigh
 	PriorityCritical
 )
+
+// Handler processes events delivered to a subscription.
+//
+// The context reports cancellation to the handler: for synchronous handlers it
+// is derived from the publish call and is canceled when the publish context is
+// canceled or the handler's timeout elapses; asynchronous handlers receive the
+// subscription context instead, because the publish call may return before they
+// run.
+//
+// A non-nil error marks the delivery as failed: it is counted in metrics,
+// reported to the bus ErrorHandler, and - for synchronous handlers - joined
+// into the error returned by the publish call. Returning an error does not
+// stop dispatch to the remaining handlers.
+type Handler[T any] func(ctx context.Context, event T) error
 
 // EventError represents an error that occurred during event handling
 type EventError struct {


### PR DESCRIPTION
Preview of the API that freezes at v1.0.0, shipped as **v0.6.0** so real usage can still shake out design flaws while v0.x permits changes. This lands the three roadmap items that gate v1: subscription API convergence, handler error reporting, and `Publish` error semantics.

## Handlers: `func(ctx context.Context, event T) error`

- A returned error counts as a failed delivery — metrics, `ErrorHandler`, and the publish return value all see it. Previously a handler could only report failure by panicking, so `ErrorHandler` never saw business errors.
- The context makes cancellation observable *inside* the handler. When a `HandlerTimeout` elapses or the publish context is canceled, the handler's ctx cancels. Before, the bus could only stop waiting for a handler; now the handler can actually stop working. Verified live by the reworked timeout tutorial: `Slow processing canceled: context canceled`.
- Sync handlers get a ctx derived from the publish call; async handlers get the subscription context (`HandlerContext`), because the publish may already have returned when they run.

## One `Subscribe` replaces ten variants

```go
handle, err := bus.Subscribe(topic, fn,
    bus.HandlerPriority(bus.PriorityHigh),
    bus.HandlerFilter(isImportant),
    bus.HandlerAsync(false),
    bus.HandlerTimeout(2*time.Second),
)
```

- The only subscription method is `Subscribe(topic, fn, opts...) (*Handle[T], error)`. Async/once/priority/filter/context became `HandlerOption`s; `HandlerFilter` is new, the rest existed.
- The single return shape fixes the silent-failure trap: helpers that returned only a handle gave `nil` with no explanation on a closed bus. The reason now comes back as an error, and an ignored nil handle stays panic-safe.
- `HandlerFilter` is generic while `HandlerOption` is not, so the filter travels as `any` and `Subscribe` re-types it, reporting a mismatch as an error (`TestFilterTypeMismatchIsRejected`).

## `Publish` returns an error

The joined failures of the **synchronous** handlers — `errors.Is` sees through the join, and ignoring the return stays legal. Dispatch continues past handler errors; only publish-ctx cancellation, bus close, or a panic under `RecoverAndStop` abort it. A *returned* error never aborts, even under `RecoverAndStop` — that policy governs panics (`TestReturnedErrorDoesNotStopDispatchUnderRecoverAndStop`).

## Migration

[MIGRATION.md](MIGRATION.md) / [MIGRATION_ZH.md](MIGRATION_ZH.md) map every old call site to its replacement, with regex hints for the mechanical part. After rewriting, `go vet` finds stragglers: every old method name is an undefined symbol.

## Scope of the port

Tests (**coverage 93.3% → 95.3%**), nine godoc examples, all four tutorials, the Prometheus adapter test, both READMEs (snippets, behavior contract, roadmap → "Preview (v0.6.0)").

## Verification

All CI steps pass locally: build/vet/race both modules, examples vetted file-by-file, gofmt, tidy-idempotence, zero-dependency assertion, coverage floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)