### PR TITLE
chore(prometheus): require bus v0.6.0 for the new subscription API

### DIFF
--- a/prometheus/go.mod
+++ b/prometheus/go.mod
@@ -7,7 +7,7 @@ require (
 	// Must be v0.5.0 or newer. Up to and including v0.4.0 the root module still
 	// bundled this package, so an older requirement makes the import path
 	// ambiguous: it would be provided by two modules at once.
-	github.com/townbell/bus v0.5.0
+	github.com/townbell/bus v0.6.0
 )
 
 // v0.5.0 required github.com/townbell/bus v0.4.0, which still contains this


### PR DESCRIPTION
The adapter test uses `Subscribe(topic, fn, opts...)`, which does not exist before v0.6.0, so the module requirement moves with it. Same release pattern as v0.5.x: core tag first, adapter requirement bumped after, adapter tagged `prometheus/v0.6.0` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)