### PR TITLE
feat: add publish error collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,9 +349,22 @@ Available options: `HandlerPriority`, `HandlerFilter`, `HandlerContext`,
 `HandlerAsync`, `HandlerOnce`, `HandlerTimeout`, `HandlerRecoverPolicy`,
 `HandlerMaxConcurrency`, `HandlerSerial`.
 
+### Collecting Handler Errors
+
+Use `PublishCollect` when each synchronous handler failure needs individual
+handling rather than a single joined error. Async failures still go to the
+configured `ErrorHandler`:
+
+```go
+for _, err := range eventBus.PublishCollect("payment.validate", payment) {
+    log.Printf("validation handler failed: %v", err)
+}
+```
+
 ## ✅ Behavior Contract
 
 - `Publish` and `PublishWithContext` return the joined failures of the synchronous handlers (`errors.Is` sees through the join). The error is safe to ignore. Asynchronous handler failures are reported through `ErrorHandler` only, because the publish call may return before they run.
+- `PublishCollect`, `PublishCollectWithContext`, and `PublishCollectWithTimeout` return each synchronous dispatch failure in handler execution order. They include context, close, and middleware failures; asynchronous handler failures remain available through `ErrorHandler` only.
 - A handler error does not stop dispatch: the remaining handlers still run. Dispatch stops early only when the publish context is canceled, the bus closes, or a handler panics under `RecoverAndStop`.
 - Synchronous handlers run in the goroutine that calls publish and receive a context derived from the publish call; asynchronous handlers run in separate goroutines and receive the subscription context (`HandlerContext`), and `HandlerAsync(true)` serializes calls to the same handler.
 - `HandlerTimeout` bounds how long the publish call waits and cancels the handler's context when it elapses; a handler that ignores its context keeps running in the background and is still awaited by `WaitAsync` and `Close`.
@@ -380,7 +393,7 @@ Townbell will keep its focus on being an in-process, type-safe, lightweight even
 | P0 | Preview (v0.6.0) | Subscription API convergence | One `Subscribe(topic, fn, opts...) (*Handle[T], error)` replaced the ten previous variants. Freezes at v1.0.0 |
 | P0 | Preview (v0.6.0) | Handler error reporting | Handlers are `func(ctx, T) error`: business failures reach metrics, the `ErrorHandler`, and the publish return value without panicking. Unblocks result collection. Freezes at v1.0.0 |
 | P0 | Preview (v0.6.0) | `Publish` error semantics | `Publish` returns the joined synchronous-handler failures; ignoring it stays legal. Freezes at v1.0.0 |
-| P2 | Planned | Result collection | Borrow from Blinker and add a `PublishCollect`-style API for collecting handler results or errors |
+| P2 | Partial (v0.9.0) | Result collection | `PublishCollect` returns each synchronous handler error in dispatch order; collecting arbitrary handler values needs a separate v1 design |
 | P2 | Done | Topic enhancements | Wildcard (`*`) topics, hierarchical `prefix.*` patterns, and a dead-event hook for publishes that reach no subscriber |
 | P2 | Partial | Integration examples | `net/http` example shipped; Gin, CLI apps, and workers remain |
 | P3 | Planned | Broker bridges | Borrow from Watermill and explore NATS / Kafka / RabbitMQ adapters, preferably in separate subpackages |
@@ -412,6 +425,13 @@ type BusPublisher[T any] interface {
     Publish(topic string, event T) error
     PublishWithContext(ctx context.Context, topic string, event T) error
     PublishWithTimeout(topic string, event T, timeout time.Duration) error
+}
+
+// Optional detailed publisher interface
+type BusResultCollector[T any] interface {
+    PublishCollect(topic string, event T) []error
+    PublishCollectWithContext(ctx context.Context, topic string, event T) []error
+    PublishCollectWithTimeout(topic string, event T, timeout time.Duration) []error
 }
 
 // Controller interface

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -343,9 +343,21 @@ handle, err := eventBus.Subscribe("payment.validate",
 `HandlerOnce`、`HandlerTimeout`、`HandlerRecoverPolicy`、`HandlerMaxConcurrency`、
 `HandlerSerial`。
 
+### 收集 Handler 错误
+
+当需要逐个处理同步 handler 的失败、而非只取得一个合并错误时，使用
+`PublishCollect`。异步 handler 的失败仍会交给配置的 `ErrorHandler`：
+
+```go
+for _, err := range eventBus.PublishCollect("payment.validate", payment) {
+    log.Printf("验证 handler 失败: %v", err)
+}
+```
+
 ## ✅ 行为约定
 
 - `Publish` 和 `PublishWithContext` 返回同步 handler 的失败合并（`errors.Is` 可以穿透）。这个错误可以安全忽略。异步 handler 的失败只通过 `ErrorHandler` 上报，因为发布调用可能在它们运行前就已返回。
+- `PublishCollect`、`PublishCollectWithContext` 和 `PublishCollectWithTimeout` 按 handler 执行顺序返回本次同步派发中的每个失败，包含 context、关闭和 middleware 错误；异步 handler 失败仍仅通过 `ErrorHandler` 上报。
 - handler 返回错误不会中断派发：后续 handler 照常执行。只有发布 context 被取消、总线关闭、或 handler 在 `RecoverAndStop` 策略下 panic 时才会提前终止派发。
 - 同步 handler 在调用发布的 goroutine 中执行，收到从发布调用派生的 context；异步 handler 在独立 goroutine 中执行，收到订阅 context（`HandlerContext`），`HandlerAsync(true)` 时同一 handler 串行执行。
 - `HandlerTimeout` 限制发布调用的等待时间，并在超时到达时取消 handler 的 context；无视 context 的 handler 会继续在后台运行，仍会被 `WaitAsync` 和 `Close` 等待。
@@ -374,7 +386,7 @@ Townbell 会优先保持“进程内、类型安全、轻量事件总线”的�
 | P0 | 试运行（v0.6.0） | 订阅 API 收敛 | 一个 `Subscribe(topic, fn, opts...) (*Handle[T], error)` 取代了此前的十个变体。将在 v1.0.0 冻结 |
 | P0 | 试运行（v0.6.0） | handler 错误上报 | handler 变为 `func(ctx, T) error`：业务失败无需 panic 即可进入指标、`ErrorHandler` 和发布返回值。解锁返回值收集。将在 v1.0.0 冻结 |
 | P0 | 试运行（v0.6.0） | `Publish` 错误语义 | `Publish` 返回同步 handler 失败的合并；忽略它依然合法。将在 v1.0.0 冻结 |
-| P2 | 未完成 | 返回值收集 | 参考 Blinker，提供 `PublishCollect` 一类 API，收集多个 handler 的返回值或错误 |
+| P2 | 部分完成（v0.9.0） | 返回值收集 | `PublishCollect` 按派发顺序返回每个同步 handler 错误；任意 handler 返回值收集需在 v1 单独设计 |
 | P2 | 已完成 | Topic 增强 | 通配符（`*`）topic、层级 `prefix.*` 模式、以及无订阅者时的 dead-event hook |
 | P2 | 部分完成 | 集成示例 | `net/http` 示例已提供；Gin、CLI、worker 待补充 |
 | P3 | 未完成 | Broker 桥接 | 参考 Watermill，探索 NATS / Kafka / RabbitMQ 适配器；优先放在独立子包，避免拖重核心库 |
@@ -406,6 +418,13 @@ type BusPublisher[T any] interface {
     Publish(topic string, event T) error
     PublishWithContext(ctx context.Context, topic string, event T) error
     PublishWithTimeout(topic string, event T, timeout time.Duration) error
+}
+
+// 可选的详细发布接口
+type BusResultCollector[T any] interface {
+    PublishCollect(topic string, event T) []error
+    PublishCollectWithContext(ctx context.Context, topic string, event T) []error
+    PublishCollectWithTimeout(topic string, event T, timeout time.Duration) []error
 }
 
 // 控制器接口

--- a/bus.go
+++ b/bus.go
@@ -234,13 +234,32 @@ func (bus *EventBus[T]) HasCallback(topic string) bool {
 // delivery failures do not matter to the caller. Asynchronous handler
 // failures are reported through the ErrorHandler instead.
 func (bus *EventBus[T]) Publish(topic string, event T) error {
-	return bus.PublishWithContext(context.Background(), topic, event)
+	return errors.Join(bus.PublishCollect(topic, event)...)
 }
 
 // PublishWithContext publishes an event with context. Canceling the context
 // aborts dispatch to the remaining handlers and cancels the context passed to
 // the currently running synchronous handler.
 func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, event T) error {
+	return errors.Join(bus.PublishCollectWithContext(ctx, topic, event)...)
+}
+
+// PublishCollect publishes an event and returns each synchronous dispatch
+// failure in handler execution order. It includes errors caused by context
+// cancellation, closing the bus, and middleware. Asynchronous handler
+// failures remain available through ErrorHandler only, because they may occur
+// after this method returns.
+//
+// A nil result means no synchronous dispatch failure occurred. The result is
+// independent of future publishes and may be inspected or retained by the
+// caller.
+func (bus *EventBus[T]) PublishCollect(topic string, event T) []error {
+	return bus.PublishCollectWithContext(context.Background(), topic, event)
+}
+
+// PublishCollectWithContext is PublishCollect with a caller-provided context.
+// A nil context is treated as context.Background.
+func (bus *EventBus[T]) PublishCollectWithContext(ctx context.Context, topic string, event T) []error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -248,7 +267,7 @@ func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, ev
 	bus.lock.RLock()
 	if bus.closed {
 		bus.lock.RUnlock()
-		return fmt.Errorf("event bus is closed")
+		return []error{fmt.Errorf("event bus is closed")}
 	}
 	logger := bus.logger
 	errorHandler := bus.errorHandler
@@ -301,13 +320,13 @@ func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, ev
 	// Fast path: with no middleware there is no reason to box the event into
 	// any or allocate the chain closures.
 	if len(middlewares) == 0 {
-		return bus.dispatch(ctx, topic, event, handlers, closeCh, logger, debugLog, errorHandler, metrics)
+		return bus.dispatchCollect(ctx, topic, event, handlers, closeCh, logger, debugLog, errorHandler, metrics)
 	}
 
-	dispatch := func() error {
-		return bus.dispatch(ctx, topic, event, handlers, closeCh, logger, debugLog, errorHandler, metrics)
+	dispatch := func() []error {
+		return bus.dispatchCollect(ctx, topic, event, handlers, closeCh, logger, debugLog, errorHandler, metrics)
 	}
-	dispatchErr, middlewareErr := runMiddlewares(middlewares, topic, event, dispatch)
+	dispatchErrs, middlewareErr := runMiddlewares(middlewares, topic, event, dispatch)
 	if middlewareErr != nil {
 		if errorHandler != nil {
 			errorHandler(&EventError{
@@ -316,19 +335,19 @@ func (bus *EventBus[T]) PublishWithContext(ctx context.Context, topic string, ev
 				Err:   middlewareErr,
 			})
 		}
-		return middlewareErr
+		return []error{middlewareErr}
 	}
-	return dispatchErr
+	return dispatchErrs
 }
 
-func runMiddlewares(middlewares []EventMiddleware[any], topic string, event any, dispatch func() error) (dispatchErr, middlewareErr error) {
+func runMiddlewares(middlewares []EventMiddleware[any], topic string, event any, dispatch func() []error) (dispatchErrs []error, middlewareErr error) {
 	var run func(int)
 	run = func(i int) {
 		if middlewareErr != nil {
 			return
 		}
 		if i == len(middlewares) {
-			dispatchErr = dispatch()
+			dispatchErrs = dispatch()
 			return
 		}
 		var nextOnce sync.Once
@@ -342,18 +361,18 @@ func runMiddlewares(middlewares []EventMiddleware[any], topic string, event any,
 		}
 	}
 	run(0)
-	return dispatchErr, middlewareErr
+	return dispatchErrs, middlewareErr
 }
 
-func (bus *EventBus[T]) dispatch(ctx context.Context, topic string, event T, handlers []*eventHandler[T], closeCh <-chan struct{}, logger Logger, debugLog bool, errorHandler ErrorHandler, metrics Metrics) error {
+func (bus *EventBus[T]) dispatchCollect(ctx context.Context, topic string, event T, handlers []*eventHandler[T], closeCh <-chan struct{}, logger Logger, debugLog bool, errorHandler ErrorHandler, metrics Metrics) []error {
 	var errs []error
 
 	for _, handler := range handlers {
 		select {
 		case <-ctx.Done():
-			return errors.Join(append(errs, ctx.Err())...)
+			return append(errs, ctx.Err())
 		case <-closeCh:
-			return errors.Join(append(errs, fmt.Errorf("event bus is closed"))...)
+			return append(errs, fmt.Errorf("event bus is closed"))
 		default:
 		}
 
@@ -379,20 +398,20 @@ func (bus *EventBus[T]) dispatch(ctx context.Context, topic string, event T, han
 				errs = append(errs, err)
 			}
 			if stop {
-				return errors.Join(errs...)
+				return errs
 			}
 			continue
 		}
 
 		if !bus.addAsync() {
-			return errors.Join(append(errs, fmt.Errorf("event bus is closed"))...)
+			return append(errs, fmt.Errorf("event bus is closed"))
 		}
 		if handler.transactional {
 			handler.Lock()
 		}
 		go bus.doPublishAsync(handler, topic, event, closeCh, logger, debugLog, errorHandler, metrics)
 	}
-	return errors.Join(errs...)
+	return errs
 }
 
 func (bus *EventBus[T]) addAsync() bool {
@@ -407,9 +426,15 @@ func (bus *EventBus[T]) addAsync() bool {
 
 // PublishWithTimeout publishes an event with timeout
 func (bus *EventBus[T]) PublishWithTimeout(topic string, event T, timeout time.Duration) error {
+	return errors.Join(bus.PublishCollectWithTimeout(topic, event, timeout)...)
+}
+
+// PublishCollectWithTimeout is PublishCollect with a timeout. A timeout is
+// reported as context.DeadlineExceeded in the returned errors.
+func (bus *EventBus[T]) PublishCollectWithTimeout(topic string, event T, timeout time.Duration) []error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	return bus.PublishWithContext(ctx, topic, event)
+	return bus.PublishCollectWithContext(ctx, topic, event)
 }
 
 // PanicError wraps a value recovered from a panicking handler. It reaches the

--- a/bus_test.go
+++ b/bus_test.go
@@ -343,6 +343,99 @@ func TestAsyncHandlerErrorGoesToErrorHandler(t *testing.T) {
 	}
 }
 
+func TestPublishCollectReturnsSynchronousErrorsInDispatchOrder(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+	bus.SetLogger(NewNoOpLogger())
+
+	errFirst := errors.New("first failure")
+	errSecond := errors.New("second failure")
+	errAsync := errors.New("async failure")
+	reported := make(chan error, 3)
+	bus.SetErrorHandler(func(eventErr *EventError) {
+		reported <- eventErr.Err
+	})
+
+	mustSubscribe(t, bus, "errors.collect", func(ctx context.Context, event TestEvent) error {
+		return errFirst
+	}, HandlerPriority(PriorityHigh))
+	mustSubscribe(t, bus, "errors.collect", func(ctx context.Context, event TestEvent) error {
+		return errSecond
+	}, HandlerPriority(PriorityNormal))
+	mustSubscribe(t, bus, "errors.collect", func(ctx context.Context, event TestEvent) error {
+		return errAsync
+	}, HandlerAsync(false), HandlerPriority(PriorityLow))
+
+	errs := bus.PublishCollect("errors.collect", TestEvent{ID: "collect", Value: 1})
+	if len(errs) != 2 {
+		t.Fatalf("Expected 2 synchronous errors, got %d: %v", len(errs), errs)
+	}
+	if !errors.Is(errs[0], errFirst) || !errors.Is(errs[1], errSecond) {
+		t.Fatalf("Expected dispatch-ordered errors [%v, %v], got %v", errFirst, errSecond, errs)
+	}
+
+	bus.WaitAsync()
+	for _, want := range []error{errFirst, errSecond, errAsync} {
+		select {
+		case got := <-reported:
+			if !errors.Is(got, want) {
+				t.Fatalf("Expected ErrorHandler error %v, got %v", want, got)
+			}
+		default:
+			t.Fatalf("Expected ErrorHandler to receive %v", want)
+		}
+	}
+}
+
+func TestPublishCollectReportsContextCancellationAfterPriorErrors(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+	bus.SetLogger(NewNoOpLogger())
+
+	errHandler := errors.New("handler failure")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var secondRan int32
+
+	mustSubscribe(t, bus, "errors.collect.context", func(ctx context.Context, event TestEvent) error {
+		cancel()
+		return errHandler
+	}, HandlerPriority(PriorityHigh))
+	mustSubscribe(t, bus, "errors.collect.context", func(ctx context.Context, event TestEvent) error {
+		atomic.AddInt32(&secondRan, 1)
+		return nil
+	}, HandlerPriority(PriorityLow))
+
+	errs := bus.PublishCollectWithContext(ctx, "errors.collect.context", TestEvent{ID: "cancel", Value: 1})
+	if len(errs) != 2 || !errors.Is(errs[0], errHandler) || !errors.Is(errs[1], context.Canceled) {
+		t.Fatalf("Expected handler error followed by context cancellation, got %v", errs)
+	}
+	if atomic.LoadInt32(&secondRan) != 0 {
+		t.Fatal("Expected context cancellation to stop dispatch before the second handler")
+	}
+}
+
+func TestPublishCollectMiddlewareErrorTakesPrecedence(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+	bus.SetLogger(NewNoOpLogger())
+
+	errHandler := errors.New("handler failure")
+	errMiddleware := errors.New("middleware failure")
+	bus.AddMiddleware(func(topic string, event any, next func()) error {
+		next()
+		return errMiddleware
+	})
+	mustSubscribe(t, bus, "errors.collect.middleware", func(ctx context.Context, event TestEvent) error {
+		return errHandler
+	})
+
+	errs := bus.PublishCollect("errors.collect.middleware", TestEvent{ID: "middleware", Value: 1})
+	if len(errs) != 1 || !errors.Is(errs[0], errMiddleware) {
+		t.Fatalf("Expected middleware error to preserve Publish semantics, got %v", errs)
+	}
+}
+
 func TestMetrics(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()

--- a/example_test.go
+++ b/example_test.go
@@ -134,6 +134,29 @@ func ExampleEventBus_Publish() {
 	// err: disk full
 }
 
+// PublishCollect exposes each synchronous dispatch failure separately when a
+// caller needs to log, retry, or classify individual handler outcomes.
+func ExampleEventBus_PublishCollect() {
+	b := bus.NewTyped[string]()
+	defer b.Close()
+	b.SetLogger(bus.NewNoOpLogger())
+
+	b.Subscribe("job.run", func(ctx context.Context, id string) error {
+		return errors.New("disk full")
+	}, bus.HandlerPriority(bus.PriorityHigh))
+	b.Subscribe("job.run", func(ctx context.Context, id string) error {
+		return errors.New("index unavailable")
+	})
+
+	for _, err := range b.PublishCollect("job.run", "j-1") {
+		fmt.Println("failure:", err)
+	}
+
+	// Output:
+	// failure: disk full
+	// failure: index unavailable
+}
+
 // Middleware wraps the whole dispatch. Calling next runs the remaining
 // middleware and then the handlers; not calling it intercepts the event.
 func ExampleEventBus_AddMiddleware() {

--- a/interfaces.go
+++ b/interfaces.go
@@ -18,6 +18,15 @@ type BusPublisher[T any] interface {
 	PublishWithTimeout(topic string, event T, timeout time.Duration) error
 }
 
+// BusResultCollector defines the optional detailed publishing behavior. It is
+// kept separate from BusPublisher so existing publisher implementations stay
+// source-compatible.
+type BusResultCollector[T any] interface {
+	PublishCollect(topic string, event T) []error
+	PublishCollectWithContext(ctx context.Context, topic string, event T) []error
+	PublishCollectWithTimeout(topic string, event T, timeout time.Duration) []error
+}
+
 // BusController defines bus control behavior
 type BusController interface {
 	HasCallback(topic string) bool


### PR DESCRIPTION
## Summary

- Add `PublishCollect`, `PublishCollectWithContext`, and `PublishCollectWithTimeout` to return synchronous dispatch failures in handler execution order.
- Preserve the joined-error behavior of `Publish`; asynchronous handler failures continue to be reported through `ErrorHandler`.
- Expose the extension through `BusResultCollector`, keeping existing `BusPublisher` implementations source-compatible.
- Add bilingual documentation, an executable example, and coverage for ordering, cancellation, middleware, and asynchronous-handler isolation.

## Impact

Callers that need to inspect each synchronous handler failure can use `PublishCollect`. Existing `Publish` call sites require no changes.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- Example build and coverage check (96.5%)
- Prometheus submodule build, vet, and race test
- `BenchmarkSyncPublish`: 0 B/op, 0 allocs/op
