### PR TITLE
docs: streamline readmes and add worker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,68 @@
 <p align="center">
-  <img src="assets/icon.png" alt="Townbell Bus Icon" width="120">
+  <img src="assets/icon.png" alt="Townbell Bus" width="120">
 </p>
 <h1 align="center">Townbell Bus</h1>
+<p align="center"><strong>A dependency-free, type-safe event bus for Go applications.</strong></p>
+
 <p align="center">
-  <strong>A High-Performance Event-Driven Architecture Library for Go</strong>
+  <a href="https://github.com/townbell/bus/actions/workflows/ci.yml"><img src="https://github.com/townbell/bus/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://pkg.go.dev/github.com/townbell/bus"><img src="https://pkg.go.dev/badge/github.com/townbell/bus.svg" alt="Go Reference"></a>
+  <a href="https://github.com/townbell/bus/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"></a>
+  <img src="https://img.shields.io/badge/go-%3E%3D1.21-blue.svg" alt="Go 1.21+">
 </p>
 
+`bus` is for in-process event dispatch: no broker, no runtime dependency, and
+no serialization layer. It gives a Go application type-safe fan-out, bounded
+asynchronous work, priority, filters, middleware, and observable failures.
 
-[![CI](https://github.com/townbell/bus/actions/workflows/ci.yml/badge.svg)](https://github.com/townbell/bus/actions/workflows/ci.yml)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.21-blue.svg)](https://golang.org/)
-[![Go Reference](https://pkg.go.dev/badge/github.com/townbell/bus.svg)](https://pkg.go.dev/github.com/townbell/bus)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/townbell/bus)](https://goreportcard.com/report/github.com/townbell/bus)
-[![Coverage](https://img.shields.io/badge/coverage-95.5%25-brightgreen.svg)](https://github.com/townbell/bus/actions/workflows/ci.yml)
+[中文文档](README_ZH.md) · [API reference](https://pkg.go.dev/github.com/townbell/bus) · [Examples](example/README.md) · [Migration from v0.5.x](MIGRATION.md)
 
+> **API preview.** Since v0.6.0, subscriptions use one
+> `Subscribe(topic, handler, options...)` method, handlers return `error`, and
+> `Publish` returns synchronous delivery failures. This API is intended to
+> freeze at v1.0.0; feedback is welcome before then.
 
+## Why Townbell?
 
-A modern, high-performance Go event bus implementation with type safety, async processing, priority handling, filters, and enterprise-grade features.
+| Need | What you get |
+| --- | --- |
+| Keep one process decoupled | Typed topics, fan-out, exact and hierarchical topic patterns |
+| Move slow work off the request path | Async handlers with serial or bounded-concurrency execution |
+| Make failures visible | Joined publish errors, per-error collection, panic recovery, error hooks, metrics |
+| Stop safely | Context-aware handlers, `WaitAsync`, and graceful `Close` |
 
-```go
-import "github.com/townbell/bus" // package bus
+If an event must survive a process restart or cross machine boundaries, use a
+durable broker. Townbell deliberately stays on the lightweight side of that
+boundary.
+
+## Dispatch model
+
+```mermaid
+flowchart LR
+    P["Publisher"] --> D["Publish(topic, event)"]
+    D --> M["Middleware chain"]
+    M --> X["Match exact + pattern handlers\n* / orders.*"]
+    X --> H["Priority, filter, and once rules"]
+    H --> S["Synchronous handler\nreturns to publisher"]
+    H --> A["Async handler\nserial or max N"]
+    S --> R["Publish error / PublishCollect"]
+    A --> E["ErrorHandler + metrics"]
 ```
 
-[中文文档](README_ZH.md)
-
-> **v0.6.0 replaced the subscription API.** One `Subscribe` method with
-> options, handlers of the form `func(ctx, T) error`, and `Publish` returns an
-> error. Coming from v0.5.x? See [MIGRATION.md](MIGRATION.md) — the rewrite is
-> mechanical. This API freezes at v1.0.0; design feedback is welcome now.
-
-## ✨ Features
-
-### 🔧 Core Features
-- **Type Safety**: Go generics ensure compile-time type safety
-- **Sync/Async**: Support for both synchronous and asynchronous event processing
-- **Handle Pattern**: Precise subscription management with unsubscribe handles
-- **Once Subscription**: One-time event handlers that auto-remove after execution
-
-### 🚀 Enterprise Features
-- **Priority Processing**: 4-level priority system (Critical, High, Normal, Low)
-- **Event Filtering**: Custom event filters for fine-grained control
-- **Context Support**: Context-based cancellation and timeout handling
-- **Middleware**: Event processing middleware chain
-- **Error Handling**: Comprehensive error handling and recovery
-- **Monitoring**: Built-in performance metrics and statistics
-- **Graceful Shutdown**: Proper resource cleanup and graceful termination
-
-### 🔒 Reliability
-- **Thread Safe**: Concurrent-safe design for multi-goroutine usage
-- **Panic Recovery**: Automatic recovery from handler panics
-- **Resource Management**: Automatic cleanup and memory management
-
-## 📦 Installation
+## Install
 
 ```bash
 go get github.com/townbell/bus
 ```
 
-The core module has no dependencies at all — importing it pulls in nothing but
-the standard library. The optional Prometheus adapter lives in its own module,
-so `client_golang` only enters your build if you ask for it:
+The core module only imports the Go standard library. Prometheus support is
+optional and lives in its own module:
 
 ```bash
 go get github.com/townbell/bus/prometheus
 ```
 
-## 🚀 Quick Start
-
-### Basic Usage
+## Quick start
 
 ```go
 package main
@@ -80,18 +75,16 @@ import (
 )
 
 type UserEvent struct {
-    UserID string
+    ID     string
     Action string
 }
 
 func main() {
-    // Create a type-safe event bus
-    eventBus := bus.NewTyped[UserEvent]()
-    defer eventBus.Close()
+    b := bus.NewTyped[UserEvent]()
+    defer b.Close()
 
-    // Subscribe to events
-    handle, err := eventBus.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
-        fmt.Printf("User %s performed %s\n", event.UserID, event.Action)
+    handle, err := b.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
+        fmt.Printf("%s: %s\n", event.ID, event.Action)
         return nil
     })
     if err != nil {
@@ -99,561 +92,92 @@ func main() {
     }
     defer handle.Unsubscribe()
 
-    // Publish events. The returned error joins any synchronous handler
-    // failures and is safe to ignore when they do not matter to the caller.
-    eventBus.Publish("user.login", UserEvent{
-        UserID: "user123",
-        Action: "login",
-    })
-}
-```
-
-## 📖 Advanced Usage
-
-### Priority Processing
-
-Handlers with different priorities execute in priority order:
-
-```go
-// High priority - security checks
-securityHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Println("🔒 Security check")
-    return nil
-}, bus.HandlerPriority(bus.PriorityCritical))
-
-// Normal priority - business logic
-businessHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Println("📋 Business processing")
-    return nil
-}, bus.HandlerPriority(bus.PriorityNormal))
-
-// Low priority - analytics
-analyticsHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Println("📊 Analytics")
-    return nil
-}, bus.HandlerPriority(bus.PriorityLow))
-```
-
-### Event Filtering
-
-Process only events that match specific criteria:
-
-```go
-// Only process admin user events
-adminHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Printf("Admin action: %s\n", event.UserID)
-    return nil
-}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
-    return strings.HasPrefix(event.UserID, "admin_")
-}))
-
-// Only process sensitive operations
-sensitiveHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Printf("Sensitive operation alert: %s\n", event.Action)
-    return nil
-}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
-    sensitiveActions := []string{"delete", "modify_permissions"}
-    for _, action := range sensitiveActions {
-        if event.Action == action {
-            return true
-        }
+    if err := b.Publish("user.login", UserEvent{ID: "u-1", Action: "login"}); err != nil {
+        fmt.Println("delivery failed:", err)
     }
-    return false
-}))
-```
-
-### Topic Patterns
-
-A subscription topic can be a pattern. `"*"` receives every event; a trailing
-`".*"` receives everything under a prefix — `orders.*` matches
-`orders.created` and `orders.created.eu`, but not `orders` itself. Pattern
-handlers merge with the topic's own handlers and run in priority order:
-
-```go
-// Audit everything under orders.
-eventBus.Subscribe("orders.*", func(ctx context.Context, event OrderEvent) error {
-    return audit.Record(ctx, event)
-}, bus.HandlerPriority(bus.PriorityLow))
-```
-
-### Dead Events
-
-Events published to a topic with no subscribed handlers are usually a
-misspelled topic. A dead-event handler makes them visible instead of silent:
-
-```go
-eventBus.SetDeadEventHandler(func(topic string, event OrderEvent) {
-    log.Printf("no subscriber for %q: %+v", topic, event)
-})
-```
-
-### Context Control
-
-Use context for cancellation and timeout control:
-
-```go
-// Context cancellation: canceling the subscription context disables the handler
-ctx, cancel := context.WithCancel(context.Background())
-handle, _ := eventBus.Subscribe("user.session", func(ctx context.Context, event UserEvent) error {
-    fmt.Printf("Session event: %s\n", event.UserID)
-    return nil
-}, bus.HandlerContext(ctx))
-
-// Cancel subscription
-cancel()
-
-// Timeout publishing. The handler's ctx is canceled when the deadline passes,
-// so a cooperative handler can stop early instead of running to completion.
-err := eventBus.PublishWithTimeout("user.action", event, 5*time.Second)
-if err != nil {
-    fmt.Printf("Publish timeout: %v\n", err)
 }
 ```
 
-### Error Handling
+## Pick a path
 
-Handlers report business failures by returning an error. The failure is
-counted in metrics, reported to the global `ErrorHandler`, and joined into the
-publish call's return value — dispatch to the remaining handlers continues:
+| I want to… | Start here | It demonstrates |
+| --- | --- | --- |
+| Learn the API | [`basic_example.go`](example/basic_example.go) | Typed subscriptions, options, async delivery |
+| Configure dispatch | [`advanced_usage.go`](example/advanced_usage.go) | Priority, filters, context, timeout, metrics |
+| Instrument every event | [`middleware_example.go`](example/middleware_example.go) | Middleware ordering and interception |
+| Publish from HTTP | [`http_example.go`](example/http_example.go) | Request contexts, patterns, dead events, shutdown |
+| Run local background jobs | [`worker_example.go`](example/worker_example.go) | Async work, `HandlerMaxConcurrency`, error hooks, draining |
+| Follow a larger flow | [`e_commerce_example.go`](example/e_commerce_example.go) | Domain events, priorities, compensation |
 
-```go
-eventBus.Subscribe("order.created", func(ctx context.Context, event OrderEvent) error {
-    if err := reserveStock(ctx, event); err != nil {
-        return fmt.Errorf("reserve stock: %w", err)
-    }
-    return nil
-})
+Run any example from its directory:
 
-if err := eventBus.Publish("order.created", order); err != nil {
-    log.Printf("delivery failures: %v", err) // errors.Is sees through the join
-}
+```bash
+cd example && go run worker_example.go
 ```
 
-Set up a global error handler to observe every failure, including those from
-asynchronous handlers (whose errors never reach the publish return value):
+## Delivery semantics
+
+| Concern | Contract |
+| --- | --- |
+| `Publish` | Runs synchronous handlers in priority order and returns their joined errors. Later handlers still run after an ordinary error. |
+| `PublishCollect` | Returns every synchronous failure in dispatch order when callers need to retry, classify, or log separately. |
+| Async handlers | Return before the handler finishes; failures are reported only through `ErrorHandler`. Use async to free the caller, not to make CPU work faster. |
+| Patterns | `*` matches every topic. `orders.*` matches `orders.created` and deeper descendants, but not `orders`. |
+| Context and timeout | Cancellation stops later synchronous dispatch and is passed to the current handler. Handlers must honor their context to stop promptly. |
+| Shutdown | `Close` rejects new publish/subscribe calls and waits for already-started async work. Call `WaitAsync` when a process must drain earlier. |
+
+Useful options compose in one subscription:
 
 ```go
-eventBus.SetErrorHandler(func(err *bus.EventError) {
-    log.Printf("Event processing error - Topic: %s, Error: %v", err.Topic, err.Err)
-})
-```
-
-Recovered panics arrive as `*bus.PanicError`, so they can be told apart from
-ordinary handler errors:
-
-```go
-var pe *bus.PanicError
-if errors.As(err, &pe) {
-    log.Printf("handler panicked with %v", pe.Value)
-}
-```
-
-### Middleware
-
-Add processing middleware:
-
-```go
-// Logging middleware
-eventBus.AddMiddleware(func(topic string, event interface{}, next func()) error {
-    start := time.Now()
-    log.Printf("Processing event: %s", topic)
-    
-    next() // Execute handlers
-    
-    log.Printf("Event processed: %s, Duration: %v", topic, time.Since(start))
-    return nil
-})
-
-// Rate limiting middleware
-eventBus.AddMiddleware(func(topic string, event interface{}, next func()) error {
-    if rateLimiter.Allow() {
-        next()
-        return nil
-    }
-    return fmt.Errorf("rate limit exceeded")
-})
-```
-
-### Monitoring Metrics
-
-Get runtime metrics:
-
-```go
-metrics := eventBus.GetMetrics()
-published, processed, failed, subscribers := metrics.GetStats()
-
-fmt.Printf("Published events: %d\n", published)
-fmt.Printf("Processed events: %d\n", processed)
-fmt.Printf("Failed events: %d\n", failed)
-fmt.Printf("Active subscribers: %d\n", subscribers)
-
-// Get topic information
-topics := eventBus.GetTopics()
-subscriberCount := eventBus.GetSubscriberCount("user.action")
-```
-
-Detailed metrics are available from the default metrics implementation:
-
-```go
-if detailed, ok := eventBus.GetMetrics().(*bus.DefaultMetrics); ok {
-    topicStats := detailed.GetTopicStats()
-    handlerStats := detailed.GetHandlerStats()
-    fmt.Println(topicStats["user.action"].ProcessedEvents)
-    fmt.Println(handlerStats)
-}
-```
-
-Prometheus integration is available as an optional subpackage:
-
-```go
-import busprom "github.com/townbell/bus/prometheus"
-
-promMetrics := busprom.New(busprom.Config{})
-eventBus := bus.NewTyped[UserEvent](
-    bus.WithMetrics[UserEvent](promMetrics),
-)
-```
-
-### Asynchronous Processing
-
-```go
-// Async processing, non-transactional (concurrent execution)
-_, err := eventBus.Subscribe("user.notification", func(ctx context.Context, event UserEvent) error {
-    return sendEmail(ctx, event.UserID)
-}, bus.HandlerAsync(false))
-
-// Async processing, transactional (serial execution)
-_, err = eventBus.Subscribe("user.audit", func(ctx context.Context, event UserEvent) error {
-    return writeAuditLog(ctx, event)
-}, bus.HandlerAsync(true))
-```
-
-### Handler Execution Control
-
-Every subscription concern is a `HandlerOption`, and they compose freely in
-one `Subscribe` call:
-
-```go
-handle, err := eventBus.Subscribe("payment.validate",
-    func(ctx context.Context, event PaymentEvent) error {
-        return validatePayment(ctx, event)
-    },
-    bus.HandlerTimeout(2*time.Second),           // cancels ctx when it elapses
-    bus.HandlerRecoverPolicy(bus.RecoverAndStop), // a panic aborts the publish
-    bus.HandlerSerial(),                          // one execution at a time
+b.Subscribe("payment.validate", validate,
     bus.HandlerPriority(bus.PriorityHigh),
+    bus.HandlerTimeout(2*time.Second),
+    bus.HandlerRecoverPolicy(bus.RecoverAndStop),
+    bus.HandlerMaxConcurrency(4),
 )
 ```
 
 Available options: `HandlerPriority`, `HandlerFilter`, `HandlerContext`,
 `HandlerAsync`, `HandlerOnce`, `HandlerTimeout`, `HandlerRecoverPolicy`,
-`HandlerMaxConcurrency`, `HandlerSerial`.
+`HandlerMaxConcurrency`, and `HandlerSerial`.
 
-### Collecting Handler Errors
+## Features at a glance
 
-Use `PublishCollect` when each synchronous handler failure needs individual
-handling rather than a single joined error. Async failures still go to the
-configured `ErrorHandler`:
+| Area | Included |
+| --- | --- |
+| Routing | Exact topics, `*`, hierarchical `prefix.*`, dead-event hook |
+| Execution | Sync/async handlers, priority, once, filter, context, timeout, serial or bounded concurrency |
+| Reliability | Panic recovery, publish error returns, `ErrorHandler`, safe handles, graceful close |
+| Observability | Global counts plus per-topic and per-handler snapshots; optional Prometheus adapter |
+| Performance | Copy-on-write subscription slices keep an unchanged synchronous publish path allocation-free |
 
-```go
-for _, err := range eventBus.PublishCollect("payment.validate", payment) {
-    log.Printf("validation handler failed: %v", err)
-}
-```
+## Project status
 
-## ✅ Behavior Contract
+| Status | Milestone | Scope |
+| --- | --- | --- |
+| ✅ | v0.6 API convergence | One options-based `Subscribe`; error-returning handlers and publishing |
+| ✅ | v0.8 publish hot path | Copy-on-write handler snapshots and zero-allocation synchronous publishing |
+| ✅ | v0.9 result collection | `PublishCollect` exposes individual synchronous delivery failures |
+| 🚧 | P2 integration examples | `net/http` and local worker examples are available; Gin and CLI guides remain |
+| Planned | P3+ | Optional broker bridges, mediator mode, and stateful features — outside the core module |
 
-- `Publish` and `PublishWithContext` return the joined failures of the synchronous handlers (`errors.Is` sees through the join). The error is safe to ignore. Asynchronous handler failures are reported through `ErrorHandler` only, because the publish call may return before they run.
-- `PublishCollect`, `PublishCollectWithContext`, and `PublishCollectWithTimeout` return each synchronous dispatch failure in handler execution order. They include context, close, and middleware failures; asynchronous handler failures remain available through `ErrorHandler` only.
-- A handler error does not stop dispatch: the remaining handlers still run. Dispatch stops early only when the publish context is canceled, the bus closes, or a handler panics under `RecoverAndStop`.
-- Synchronous handlers run in the goroutine that calls publish and receive a context derived from the publish call; asynchronous handlers run in separate goroutines and receive the subscription context (`HandlerContext`), and `HandlerAsync(true)` serializes calls to the same handler.
-- `HandlerTimeout` bounds how long the publish call waits and cancels the handler's context when it elapses; a handler that ignores its context keeps running in the background and is still awaited by `WaitAsync` and `Close`.
-- Handler panics are recovered as `*PanicError`, counted as failures, and reported through `ErrorHandler`; `RecoverAndContinue` (the default) keeps dispatching, `RecoverAndStop` aborts the publish call. Either way the recovered panic appears in the publish error and is detectable with `errors.As`.
-- Middleware must call `next()` to continue to the next middleware and handlers; skipping `next()` intercepts the event.
-- `HandlerOnce` handlers execute successfully at most once, including when multiple one-time handlers share a topic.
-- After `Close`, the bus rejects new publish and subscribe calls; already-started async handlers are allowed to finish.
-- `Subscribe` returns `(nil, error)` when the subscription is rejected (nil callback, mismatched filter type, or a closed bus). A `nil` handle is safe to use: `Unsubscribe` returns an error and `IsActive` returns `false`, so ignoring the error and deferring `Unsubscribe` never panics.
-- Pattern subscriptions: `"*"` matches every topic, `"prefix.*"` matches every topic strictly under `prefix.` (not `prefix` itself). Matched pattern handlers merge with exact-topic handlers and run in priority order; pattern names are sorted so same-priority ordering is deterministic. `HasCallback` and `GetSubscriberCount` remain exact-key lookups.
-- The dead-event handler fires when a publish finds zero subscribed handlers, before middleware runs. A subscriber whose filter rejects the event still counts as a subscriber, so no dead event fires. It runs synchronously in the publishing goroutine.
+## Quality and performance
 
-## 🗺️ RoadMap
-
-Townbell will keep its focus on being an in-process, type-safe, lightweight event bus. Future work may borrow ideas from Watermill, Blinker, MediatR, and Guava EventBus, but the core package will not try to become a full distributed messaging system.
-
-| Priority | Status | Area | Notes |
-| --- | --- | --- | --- |
-| P0 | Done | Core correctness | Publish no longer holds the bus lock while running handlers; `SubscribeOnce` removal, middleware chaining, and race tests are covered |
-| P0 | Done | API contract | Error returns for `Publish` / `PublishWithContext`, panic recovery, sync/async execution, and closed-bus behavior are documented |
-| P1 | Done | Documentation alignment | README content now documents the current P1 behavior and examples |
-| P1 | Done | Observability | Per-topic and per-handler published, processed, failed, and duration metrics are available, with an optional Prometheus adapter |
-| P1 | Done | Execution control | `SubscribeWithOptions` supports handler-level timeout, recover policy, async/serial execution, and max concurrency |
-| P1 | Done | Continuous integration | GitHub Actions runs build, vet, race tests, a gofmt gate and a coverage floor across a Go version matrix, and vets `example/` explicitly |
-| P1 | Done | Dependency-free core | The Prometheus adapter moved into its own module, so importing `bus` pulls in nothing but the standard library |
-| P1 | Done | Runnable documentation | Godoc `Example` functions execute in CI with verified output and render on pkg.go.dev |
-| P0 | Preview (v0.6.0) | Subscription API convergence | One `Subscribe(topic, fn, opts...) (*Handle[T], error)` replaced the ten previous variants. Freezes at v1.0.0 |
-| P0 | Preview (v0.6.0) | Handler error reporting | Handlers are `func(ctx, T) error`: business failures reach metrics, the `ErrorHandler`, and the publish return value without panicking. Unblocks result collection. Freezes at v1.0.0 |
-| P0 | Preview (v0.6.0) | `Publish` error semantics | `Publish` returns the joined synchronous-handler failures; ignoring it stays legal. Freezes at v1.0.0 |
-| P2 | Partial (v0.9.0) | Result collection | `PublishCollect` returns each synchronous handler error in dispatch order; collecting arbitrary handler values needs a separate v1 design |
-| P2 | Done | Topic enhancements | Wildcard (`*`) topics, hierarchical `prefix.*` patterns, and a dead-event hook for publishes that reach no subscriber |
-| P2 | Partial | Integration examples | `net/http` example shipped; Gin, CLI apps, and workers remain |
-| P3 | Planned | Broker bridges | Borrow from Watermill and explore NATS / Kafka / RabbitMQ adapters, preferably in separate subpackages |
-| P3 | Planned | Mediator mode | Borrow from MediatR and add request / response, command, query, and notification support only if needed |
-| P4 | Planned | Stateful features | Evaluate sticky events, event replay, and local persistence only when there is a clear use case |
-
-## 🏗️ Architecture Design
-
-The library is organized into separate modules for better maintainability:
-
-### File Structure
-
-- **`types.go`** - Core type definitions (Priority, EventError, filters, middleware)
-- **`interfaces.go`** - Interface definitions (BusSubscriber, BusPublisher, BusController, Bus)
-- **`metrics.go`** - Monitoring and metrics functionality
-- **`handle.go`** - Subscription handle management and internal handler structures
-- **`bus.go`** - Core EventBus implementation
-
-### Interface Separation
-
-```go
-// Subscriber interface
-type BusSubscriber[T any] interface {
-    Subscribe(topic string, fn Handler[T], options ...HandlerOption) (*Handle[T], error)
-}
-
-// Publisher interface
-type BusPublisher[T any] interface {
-    Publish(topic string, event T) error
-    PublishWithContext(ctx context.Context, topic string, event T) error
-    PublishWithTimeout(topic string, event T, timeout time.Duration) error
-}
-
-// Optional detailed publisher interface
-type BusResultCollector[T any] interface {
-    PublishCollect(topic string, event T) []error
-    PublishCollectWithContext(ctx context.Context, topic string, event T) []error
-    PublishCollectWithTimeout(topic string, event T, timeout time.Duration) []error
-}
-
-// Controller interface
-type BusController interface {
-    GetMetrics() Metrics
-    SetErrorHandler(handler ErrorHandler)
-    AddMiddleware(middleware EventMiddleware[any])
-    Close() error
-    // ...
-}
-```
-
-### Type System
-
-```go
-// Event handler
-type Handler[T any] func(ctx context.Context, event T) error
-
-// Event filter
-type EventFilter[T any] func(topic string, event T) bool
-
-// Event middleware
-type EventMiddleware[T any] func(topic string, event T, next func()) error
-
-// Error handler
-type ErrorHandler func(err *EventError)
-
-// Priority levels
-type Priority int
-const (
-    PriorityLow Priority = iota
-    PriorityNormal
-    PriorityHigh
-    PriorityCritical
-)
-```
-
-## 🔧 Best Practices
-
-### 1. Event Design Patterns
-
-Following industry best practices, supports these event design patterns:
-
-#### Event Notification
-```go
-type UserCreatedEvent struct {
-    UserID    string    `json:"user_id"`
-    Timestamp time.Time `json:"timestamp"`
-    // Minimal data, subscribers fetch details themselves
-}
-```
-
-#### Event-Carried State Transfer
-```go
-type UserUpdatedEvent struct {
-    UserID       string                 `json:"user_id"`
-    Timestamp    time.Time              `json:"timestamp"`
-    OldState     map[string]interface{} `json:"old_state"`
-    NewState     map[string]interface{} `json:"new_state"`
-    ChangedFields []string              `json:"changed_fields"`
-}
-```
-
-### 2. Naming Conventions
-
-```go
-// Use dot-separated hierarchical naming
-"user.created"
-"user.updated"
-"user.deleted"
-"order.placed"
-"order.cancelled"
-"payment.processed"
-"payment.failed"
-
-// Or use namespaces
-"ecommerce.order.created"
-"auth.user.login"
-"notification.email.sent"
-```
-
-### 3. Error Handling Strategy
-
-```go
-// Set up retry mechanism
-eventBus.SetErrorHandler(func(err *EventError) {
-    switch err.Err.(type) {
-    case *TemporaryError:
-        // Temporary error, retry later
-        retryQueue.Add(err.Topic, err.Event)
-    case *PermanentError:
-        // Permanent error, log and alert
-        logger.Error("Permanent error", err)
-        alerting.Send(err)
-    default:
-        // Unknown error, log details
-        logger.Warn("Unknown error", err)
-    }
-})
-```
-
-### 4. Performance Optimization
-
-```go
-// Use async for non-critical paths
-eventBus.Subscribe("analytics.track", func(ctx context.Context, event UserEvent) error {
-    return analytics.Track(ctx, event) // Non-critical analytics
-}, bus.HandlerAsync(false))
-
-// Use sync for critical paths
-eventBus.Subscribe("payment.validate", func(ctx context.Context, event PaymentEvent) error {
-    return validatePayment(ctx, event) // Critical payment validation
-})
-
-// Use filters to reduce unnecessary processing
-eventBus.Subscribe("user.activity", handler, bus.HandlerFilter(
-    func(topic string, event UserEvent) bool {
-        return event.IsImportant() // Only process important events
-    }))
-```
-
-## 🔍 Comparison with Other Libraries
-
-| Feature | Townbell | Guava EventBus | RxJava | Node.js EventEmitter |
-|---------|---------|----------------|---------|---------------------|
-| Type Safety | ✅ Generics | ✅ | ✅ | ❌ |
-| Async Processing | ✅ | ❌ | ✅ | ✅ |
-| Priority | ✅ | ❌ | ❌ | ❌ |
-| Filters | ✅ | ❌ | ✅ | ❌ |
-| Middleware | ✅ | ❌ | ✅ | ❌ |
-| Error Handling | ✅ | ⚠️ | ✅ | ⚠️ |
-| Monitoring | ✅ | ❌ | ❌ | ❌ |
-| Context Support | ✅ | ❌ | ❌ | ❌ |
-
-## 🧪 Testing
-
-Run the complete test suite. The Prometheus adapter is a separate module, so it
-needs its own invocation:
+The CI matrix builds, vets, runs race tests, checks formatting, and enforces a
+90% core coverage floor. The core benchmark suite measures parallel publishing;
+run it on your hardware before making latency claims.
 
 ```bash
 go test -race ./...
 (cd prometheus && go test -race ./...)
-```
-
-Files under `example/` carry `//go:build ignore`, which means `go vet ./...`
-skips them. Vet them by name:
-
-```bash
-for f in example/*.go; do go vet "$f"; done
-```
-
-Generate a coverage report:
-
-```bash
-go test -coverprofile=coverage.out ./...
-go tool cover -html=coverage.out -o coverage.html
-```
-
-**Current coverage: 95.5%** for the core module, 79.7% for the Prometheus
-adapter. CI enforces a 90% floor on the core module, so this figure cannot
-silently drift.
-
-Run the benchmarks:
-
-```bash
 go test -bench=. -benchmem
 ```
 
-## 📈 Performance
+## Contributing
 
-Measured on an Apple M5 (10 cores), Go 1.22.12, darwin/arm64, on 2026-07-27
-(v0.8.0). Every benchmark uses `b.RunParallel`, so `ns/op` is the aggregate
-cost across all cores rather than single-goroutine latency.
+Issues and pull requests are welcome. Please keep the core dependency-free,
+add a focused test for behavioral changes, and run the quality commands above.
 
-| Benchmark | ns/op | B/op | allocs/op |
-| --- | --- | --- | --- |
-| `SyncPublish` (1 subscriber) | 350 | 0 | 0 |
-| `AsyncPublish` (1 subscriber) | 784 | 128 | 1 |
-| `MultipleSubscribers` (10 subscribers) | 2580 | 0 | 0 |
-| `WithPriority` | 254 | 0 | 0 |
-| `WithFilter` | 63 | 0 | 0 |
-| `ConcurrentSubscribeUnsubscribe` | 2964 | 713 | 14 |
-| `ChannelBaseline` (raw Go channel) | 49 | 0 | 0 |
+## License
 
-**Synchronous publishing allocates nothing.** Handler lists are copy-on-write:
-subscription changes build fresh slices, so a publish uses the current list
-directly instead of copying it, and the middleware machinery and debug logging
-are skipped entirely when unused. v0.8.0 cut a sync publish from 839 ns and
-11 allocations to 350 ns and zero.
-
-Two more things worth reading off this table:
-
-- **Asynchronous publishing is slower than synchronous publishing**, not faster.
-  Every async dispatch starts a goroutine and touches a `WaitGroup` and a mutex.
-  Reach for async to keep a slow handler off the publishing goroutine, not to
-  raise throughput.
-- **A raw channel is still cheaper** — about 2x on a single goroutine. The bus
-  buys you fan-out, priorities, filters, middleware and metrics. If all you
-  need is to hand a value to one known goroutine, a channel is the better tool.
-
-Numbers on your hardware will differ. Re-run the benchmarks rather than trusting
-this table.
-
-## 🤝 Contributing
-
-We welcome Issues and Pull Requests!
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## 📄 License
-
-MIT License - see the [LICENSE](LICENSE) file for details
-
-## 🙏 Acknowledgments
-
-This project draws inspiration from these excellent open source projects and design patterns:
-
-- [Guava EventBus](https://github.com/google/guava) - The classic Java implementation
-- [MBassador](https://github.com/bennidi/mbassador) - High-performance Java EventBus
-- [Node.js EventEmitter](https://nodejs.org/api/events.html) - JavaScript native event system
-- [Enterprise Integration Patterns](https://www.enterpriseintegrationpatterns.com/) - Enterprise integration patterns
+[MIT](LICENSE)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,72 +1,62 @@
 <p align="center">
-  <img src="assets/icon.png" alt="Townbell Bus Icon" width="120">
+  <img src="assets/icon.png" alt="Townbell Bus" width="120">
 </p>
 <h1 align="center">Townbell Bus</h1>
+<p align="center"><strong>为 Go 应用提供零依赖、类型安全的进程内事件总线。</strong></p>
+
 <p align="center">
-  <strong>一个高性能、支持泛型的 Go 事件驱动架构库</strong>
+  <a href="https://github.com/townbell/bus/actions/workflows/ci.yml"><img src="https://github.com/townbell/bus/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://pkg.go.dev/github.com/townbell/bus"><img src="https://pkg.go.dev/badge/github.com/townbell/bus.svg" alt="Go Reference"></a>
+  <a href="https://github.com/townbell/bus/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"></a>
+  <img src="https://img.shields.io/badge/go-%3E%3D1.21-blue.svg" alt="Go 1.21+">
 </p>
 
+`bus` 专注于进程内事件派发：没有消息代理、运行时依赖或序列化层。它为 Go 应用提供类型安全的扇出、受控异步执行、优先级、过滤器、中间件，以及可观测的失败处理。
 
-[![CI](https://github.com/townbell/bus/actions/workflows/ci.yml/badge.svg)](https://github.com/townbell/bus/actions/workflows/ci.yml)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.21-blue.svg)](https://golang.org/)
-[![Go Reference](https://pkg.go.dev/badge/github.com/townbell/bus.svg)](https://pkg.go.dev/github.com/townbell/bus)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/townbell/bus)](https://goreportcard.com/report/github.com/townbell/bus)
-[![Coverage](https://img.shields.io/badge/coverage-95.5%25-brightgreen.svg)](https://github.com/townbell/bus/actions/workflows/ci.yml)
+[English](README.md) · [API 参考](https://pkg.go.dev/github.com/townbell/bus) · [示例](example/README_ZH.md) · [从 v0.5.x 迁移](MIGRATION_ZH.md)
 
+> **API 试运行中。** 自 v0.6.0 起，订阅统一为
+> `Subscribe(topic, handler, options...)`；handler 返回 `error`，`Publish`
+> 返回同步派发失败。这套 API 计划在 v1.0.0 冻结，冻结前欢迎反馈。
 
+## 为什么选择 Townbell？
 
-一个现代化的、高性能的 Go 事件总线实现，支持泛型、异步处理、优先级、过滤器等企业级功能。
+| 你的需求 | 得到的能力 |
+| --- | --- |
+| 解耦同一进程内的模块 | 类型安全 topic、扇出、精确和层级 topic 模式 |
+| 把慢操作移出请求路径 | 异步 handler，支持串行或限制最大并发 |
+| 让失败真正可见 | 合并发布错误、逐项错误收集、panic 恢复、错误钩子、指标 |
+| 安全退出 | 感知 context 的 handler、`WaitAsync` 与优雅 `Close` |
 
-```go
-import "github.com/townbell/bus" // 包名为 bus
+如果事件必须跨进程、跨机器，或在重启后仍然存在，请使用持久化消息代理。Townbell 有意保持在这条边界的轻量一侧。
+
+## 派发模型
+
+```mermaid
+flowchart LR
+    P["发布方"] --> D["Publish(topic, event)"]
+    D --> M["中间件链"]
+    M --> X["匹配精确和模式 handler\n* / orders.*"]
+    X --> H["优先级、过滤和一次性规则"]
+    H --> S["同步 handler\n结果返回发布方"]
+    H --> A["异步 handler\n串行或最大 N"]
+    S --> R["Publish 错误 / PublishCollect"]
+    A --> E["ErrorHandler + 指标"]
 ```
 
-[English Documentation](README.md)
-
-> **v0.6.0 替换了订阅 API。** 一个带选项的 `Subscribe`、形如 `func(ctx, T) error`
-> 的 handler、返回 error 的 `Publish`。从 v0.5.x 升级请看
-> [MIGRATION_ZH.md](MIGRATION_ZH.md)——改写是机械性的。这套 API 将在 v1.0.0
-> 冻结，现在正是提设计反馈的时候。
-
-## ✨ 特性
-
-### 🔧 核心功能
-- **类型安全**: 使用 Go 泛型确保编译时类型安全
-- **同步/异步**: 支持同步和异步事件处理
-- **Handle 模式**: 支持精确的订阅取消
-- **一次性订阅**: 支持只触发一次的事件处理器
-
-### 🚀 企业级功能
-- **优先级处理**: 支持 4 级优先级（Critical, High, Normal, Low）
-- **事件过滤**: 支持自定义过滤器
-- **上下文支持**: 支持 context.Context 取消和超时
-- **中间件**: 支持事件处理中间件链
-- **错误处理**: 完善的错误处理和恢复机制
-- **监控指标**: 内置性能监控和统计
-- **优雅关闭**: 支持优雅关闭和资源清理
-
-### 🔒 可靠性
-- **并发安全**: 线程安全设计
-- **Panic 恢复**: 自动恢复处理器 panic
-- **资源管理**: 自动资源清理和内存管理
-
-## 📦 安装
+## 安装
 
 ```bash
 go get github.com/townbell/bus
 ```
 
-核心模块**没有任何依赖**，引入它只会带进标准库。可选的 Prometheus 适配器是独立模块，
-只有你主动安装时 `client_golang` 才会进入你的构建：
+核心模块只导入 Go 标准库。Prometheus 支持是可选的独立模块：
 
 ```bash
 go get github.com/townbell/bus/prometheus
 ```
 
-## 🚀 快速开始
-
-### 基本使用
+## 快速开始
 
 ```go
 package main
@@ -79,18 +69,16 @@ import (
 )
 
 type UserEvent struct {
-    UserID string
+    ID     string
     Action string
 }
 
 func main() {
-    // 创建类型安全的事件总线
-    eventBus := bus.NewTyped[UserEvent]()
-    defer eventBus.Close()
+    b := bus.NewTyped[UserEvent]()
+    defer b.Close()
 
-    // 订阅事件
-    handle, err := eventBus.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
-        fmt.Printf("用户 %s 执行了 %s\n", event.UserID, event.Action)
+    handle, err := b.Subscribe("user.login", func(ctx context.Context, event UserEvent) error {
+        fmt.Printf("%s: %s\n", event.ID, event.Action)
         return nil
     })
     if err != nil {
@@ -98,548 +86,87 @@ func main() {
     }
     defer handle.Unsubscribe()
 
-    // 发布事件。返回值合并了同步 handler 的失败，不关心时可以直接忽略。
-    eventBus.Publish("user.login", UserEvent{
-        UserID: "user123",
-        Action: "login",
-    })
-}
-```
-
-## 📖 详细使用
-
-### 优先级处理
-
-不同优先级的处理器会按优先级顺序执行：
-
-```go
-// 高优先级 - 安全检查
-securityHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Println("🔒 安全检查")
-    return nil
-}, bus.HandlerPriority(bus.PriorityCritical))
-
-// 普通优先级 - 业务逻辑
-businessHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Println("📋 业务处理")
-    return nil
-}, bus.HandlerPriority(bus.PriorityNormal))
-
-// 低优先级 - 统计分析
-analyticsHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Println("📊 数据统计")
-    return nil
-}, bus.HandlerPriority(bus.PriorityLow))
-```
-
-### 事件过滤
-
-只处理符合条件的事件：
-
-```go
-// 只处理管理员用户的事件
-adminHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Printf("管理员操作: %s\n", event.UserID)
-    return nil
-}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
-    return strings.HasPrefix(event.UserID, "admin_")
-}))
-
-// 只处理敏感操作
-sensitiveHandle, _ := eventBus.Subscribe("user.action", func(ctx context.Context, event UserEvent) error {
-    fmt.Printf("敏感操作告警: %s\n", event.Action)
-    return nil
-}, bus.HandlerFilter(func(topic string, event UserEvent) bool {
-    sensitiveActions := []string{"delete", "modify_permissions"}
-    for _, action := range sensitiveActions {
-        if event.Action == action {
-            return true
-        }
+    if err := b.Publish("user.login", UserEvent{ID: "u-1", Action: "login"}); err != nil {
+        fmt.Println("派发失败:", err)
     }
-    return false
-}))
-```
-
-### Topic 模式
-
-订阅的 topic 可以是模式。`"*"` 接收所有事件；末尾的 `".*"` 接收某个前缀之下的
-全部事件——`orders.*` 匹配 `orders.created` 和 `orders.created.eu`，但不匹配
-`orders` 本身。模式 handler 会与该 topic 的精确 handler 合并，按优先级顺序执行：
-
-```go
-// 审计 orders 之下的一切
-eventBus.Subscribe("orders.*", func(ctx context.Context, event OrderEvent) error {
-    return audit.Record(ctx, event)
-}, bus.HandlerPriority(bus.PriorityLow))
-```
-
-### Dead Events
-
-发布到无人订阅的 topic 的事件通常意味着 topic 拼错了。dead-event handler
-让它们显形，而不是无声消失：
-
-```go
-eventBus.SetDeadEventHandler(func(topic string, event OrderEvent) {
-    log.Printf("没有订阅者的 topic %q: %+v", topic, event)
-})
-```
-
-### 上下文控制
-
-使用 context 进行取消和超时控制：
-
-```go
-// 上下文取消：取消订阅 context 会停用该 handler
-ctx, cancel := context.WithCancel(context.Background())
-handle, _ := eventBus.Subscribe("user.session", func(ctx context.Context, event UserEvent) error {
-    fmt.Printf("会话事件: %s\n", event.UserID)
-    return nil
-}, bus.HandlerContext(ctx))
-
-// 取消订阅
-cancel()
-
-// 超时发布。截止时间一到，handler 的 ctx 会被取消，
-// 配合的 handler 可以提前停止，而不是继续跑完。
-err := eventBus.PublishWithTimeout("user.action", event, 5*time.Second)
-if err != nil {
-    fmt.Printf("发布超时: %v\n", err)
 }
 ```
 
-### 错误处理
+## 按场景选示例
 
-handler 通过返回 error 上报业务失败。失败会计入指标、上报给全局 `ErrorHandler`，
-并合并进发布调用的返回值——对后续 handler 的派发继续进行：
+| 想做什么 | 从这里开始 | 你会看到 |
+| --- | --- | --- |
+| 熟悉 API | [`basic_example.go`](example/basic_example.go) | 类型安全订阅、选项、异步派发 |
+| 配置派发行为 | [`advanced_usage.go`](example/advanced_usage.go) | 优先级、过滤、context、超时、指标 |
+| 观测每一个事件 | [`middleware_example.go`](example/middleware_example.go) | 中间件顺序和拦截 |
+| 从 HTTP 发布事件 | [`http_example.go`](example/http_example.go) | 请求 context、模式、dead event、退出 |
+| 运行本地后台任务 | [`worker_example.go`](example/worker_example.go) | 异步任务、`HandlerMaxConcurrency`、错误钩子、排空 |
+| 了解完整业务流 | [`e_commerce_example.go`](example/e_commerce_example.go) | 领域事件、优先级、补偿 |
 
-```go
-eventBus.Subscribe("order.created", func(ctx context.Context, event OrderEvent) error {
-    if err := reserveStock(ctx, event); err != nil {
-        return fmt.Errorf("预留库存: %w", err)
-    }
-    return nil
-})
+在 `example` 目录中单独运行任一示例：
 
-if err := eventBus.Publish("order.created", order); err != nil {
-    log.Printf("投递失败: %v", err) // errors.Is 可以穿透合并后的错误
-}
+```bash
+cd example && go run worker_example.go
 ```
 
-设置全局错误处理器可以观察到全部失败，包括异步 handler 的
-（它们的错误不会出现在发布调用的返回值里）：
+## 派发语义
+
+| 关注点 | 约定 |
+| --- | --- |
+| `Publish` | 按优先级运行同步 handler，返回这些 handler 的合并错误。普通错误不会阻止后续 handler。 |
+| `PublishCollect` | 需要分别重试、分类或记录时，按派发顺序返回每一项同步失败。 |
+| 异步 handler | 发布调用会先返回；失败只通过 `ErrorHandler` 上报。异步的目的是释放调用方，而不是让 CPU 工作变快。 |
+| 模式 | `*` 匹配全部 topic；`orders.*` 匹配 `orders.created` 及更深层级，但不匹配 `orders` 本身。 |
+| Context 与超时 | 取消会停止后续同步派发，并传递给当前 handler。handler 必须配合检查 context 才能及时停止。 |
+| 关闭 | `Close` 拒绝新的发布和订阅，并等待已启动的异步工作；需要提前排空时调用 `WaitAsync`。 |
+
+一个订阅中的常用选项可以自由组合：
 
 ```go
-eventBus.SetErrorHandler(func(err *bus.EventError) {
-    log.Printf("事件处理错误 - 主题: %s, 错误: %v", err.Topic, err.Err)
-})
-```
-
-恢复的 panic 以 `*bus.PanicError` 的形式到达，可以与普通 handler 错误区分开：
-
-```go
-var pe *bus.PanicError
-if errors.As(err, &pe) {
-    log.Printf("handler panic: %v", pe.Value)
-}
-```
-
-### 中间件
-
-添加处理中间件：
-
-```go
-// 日志中间件
-eventBus.AddMiddleware(func(topic string, event interface{}, next func()) error {
-    start := time.Now()
-    log.Printf("开始处理事件: %s", topic)
-    
-    next() // 执行处理器
-    
-    log.Printf("事件处理完成: %s, 耗时: %v", topic, time.Since(start))
-    return nil
-})
-
-// 限流中间件
-eventBus.AddMiddleware(func(topic string, event interface{}, next func()) error {
-    if rateLimiter.Allow() {
-        next()
-        return nil
-    }
-    return fmt.Errorf("rate limit exceeded")
-})
-```
-
-### 监控指标
-
-获取运行时指标：
-
-```go
-metrics := eventBus.GetMetrics()
-published, processed, failed, subscribers := metrics.GetStats()
-
-fmt.Printf("发布事件: %d\n", published)
-fmt.Printf("处理事件: %d\n", processed)
-fmt.Printf("失败事件: %d\n", failed)
-fmt.Printf("活跃订阅者: %d\n", subscribers)
-
-// 获取主题信息
-topics := eventBus.GetTopics()
-subscriberCount := eventBus.GetSubscriberCount("user.action")
-```
-
-默认指标实现还提供 topic / handler 维度的快照：
-
-```go
-if detailed, ok := eventBus.GetMetrics().(*bus.DefaultMetrics); ok {
-    topicStats := detailed.GetTopicStats()
-    handlerStats := detailed.GetHandlerStats()
-    fmt.Println(topicStats["user.action"].ProcessedEvents)
-    fmt.Println(handlerStats)
-}
-```
-
-Prometheus 集成放在可选子包中：
-
-```go
-import busprom "github.com/townbell/bus/prometheus"
-
-promMetrics := busprom.New(busprom.Config{})
-eventBus := bus.NewTyped[UserEvent](
-    bus.WithMetrics[UserEvent](promMetrics),
-)
-```
-
-### 异步处理
-
-```go
-// 异步处理，非事务性（并发执行）
-_, err := eventBus.Subscribe("user.notification", func(ctx context.Context, event UserEvent) error {
-    return sendEmail(ctx, event.UserID)
-}, bus.HandlerAsync(false))
-
-// 异步处理，事务性（串行执行）
-_, err = eventBus.Subscribe("user.audit", func(ctx context.Context, event UserEvent) error {
-    return writeAuditLog(ctx, event)
-}, bus.HandlerAsync(true))
-```
-
-### Handler 执行控制
-
-所有订阅关注点都是 `HandlerOption`，可以在一次 `Subscribe` 调用中自由组合：
-
-```go
-handle, err := eventBus.Subscribe("payment.validate",
-    func(ctx context.Context, event PaymentEvent) error {
-        return validatePayment(ctx, event)
-    },
-    bus.HandlerTimeout(2*time.Second),            // 超时到达时取消 ctx
-    bus.HandlerRecoverPolicy(bus.RecoverAndStop), // panic 中止本次发布
-    bus.HandlerSerial(),                          // 同一时间只执行一个
+b.Subscribe("payment.validate", validate,
     bus.HandlerPriority(bus.PriorityHigh),
+    bus.HandlerTimeout(2*time.Second),
+    bus.HandlerRecoverPolicy(bus.RecoverAndStop),
+    bus.HandlerMaxConcurrency(4),
 )
 ```
 
-可用选项：`HandlerPriority`、`HandlerFilter`、`HandlerContext`、`HandlerAsync`、
-`HandlerOnce`、`HandlerTimeout`、`HandlerRecoverPolicy`、`HandlerMaxConcurrency`、
-`HandlerSerial`。
+可用选项：`HandlerPriority`、`HandlerFilter`、`HandlerContext`、`HandlerAsync`、`HandlerOnce`、`HandlerTimeout`、`HandlerRecoverPolicy`、`HandlerMaxConcurrency`、`HandlerSerial`。
 
-### 收集 Handler 错误
+## 能力一览
 
-当需要逐个处理同步 handler 的失败、而非只取得一个合并错误时，使用
-`PublishCollect`。异步 handler 的失败仍会交给配置的 `ErrorHandler`：
+| 领域 | 已提供 |
+| --- | --- |
+| 路由 | 精确 topic、`*`、层级 `prefix.*`、dead-event 钩子 |
+| 执行 | 同步/异步 handler、优先级、一次性、过滤、context、超时、串行或限并发 |
+| 可靠性 | panic 恢复、发布错误返回、`ErrorHandler`、安全 handle、优雅关闭 |
+| 可观测性 | 全局计数和 topic / handler 维度快照；可选 Prometheus 适配器 |
+| 性能 | 订阅列表 copy-on-write，未变更时的同步发布路径保持零分配 |
 
-```go
-for _, err := range eventBus.PublishCollect("payment.validate", payment) {
-    log.Printf("验证 handler 失败: %v", err)
-}
-```
+## 项目状态
 
-## ✅ 行为约定
+| 状态 | 里程碑 | 范围 |
+| --- | --- | --- |
+| ✅ | v0.6 API 收敛 | 一个基于选项的 `Subscribe`；handler 与发布均可返回错误 |
+| ✅ | v0.8 发布热路径 | handler 快照 copy-on-write，同步发布零分配 |
+| ✅ | v0.9 错误收集 | `PublishCollect` 暴露每一项同步派发失败 |
+| 🚧 | P2 集成示例 | 已提供 `net/http` 和本地 worker 示例；Gin、CLI 指南待补充 |
+| 计划中 | P3+ | 可选 broker 桥接、Mediator 模式、状态型能力——均不进入核心模块 |
 
-- `Publish` 和 `PublishWithContext` 返回同步 handler 的失败合并（`errors.Is` 可以穿透）。这个错误可以安全忽略。异步 handler 的失败只通过 `ErrorHandler` 上报，因为发布调用可能在它们运行前就已返回。
-- `PublishCollect`、`PublishCollectWithContext` 和 `PublishCollectWithTimeout` 按 handler 执行顺序返回本次同步派发中的每个失败，包含 context、关闭和 middleware 错误；异步 handler 失败仍仅通过 `ErrorHandler` 上报。
-- handler 返回错误不会中断派发：后续 handler 照常执行。只有发布 context 被取消、总线关闭、或 handler 在 `RecoverAndStop` 策略下 panic 时才会提前终止派发。
-- 同步 handler 在调用发布的 goroutine 中执行，收到从发布调用派生的 context；异步 handler 在独立 goroutine 中执行，收到订阅 context（`HandlerContext`），`HandlerAsync(true)` 时同一 handler 串行执行。
-- `HandlerTimeout` 限制发布调用的等待时间，并在超时到达时取消 handler 的 context；无视 context 的 handler 会继续在后台运行，仍会被 `WaitAsync` 和 `Close` 等待。
-- handler panic 会以 `*PanicError` 的形式被恢复、计入失败并通过 `ErrorHandler` 上报；`RecoverAndContinue`（默认）继续派发，`RecoverAndStop` 中止本次发布。两种情况下恢复的 panic 都会出现在发布错误里，可用 `errors.As` 识别。
-- middleware 必须调用 `next()` 才会继续执行后续 middleware 和 handler；不调用 `next()` 可用于拦截事件。
-- `HandlerOnce` 的 handler 只会成功执行一次，即使同一 topic 下有多个一次性 handler。
-- `Close` 后不再接受新发布或订阅；已启动的异步 handler 会在关闭流程中等待完成。
-- 订阅被拒绝时（callback 为 nil、filter 类型不匹配、或总线已关闭），`Subscribe` 返回 `(nil, error)`。`nil` handle 可以安全使用：`Unsubscribe` 返回错误、`IsActive` 返回 `false`，因此忽略错误后 `defer handle.Unsubscribe()` 也不会 panic。
-- 模式订阅：`"*"` 匹配所有 topic，`"prefix.*"` 匹配严格位于 `prefix.` 之下的所有 topic（不含 `prefix` 本身）。命中的模式 handler 与精确 topic 的 handler 合并后按优先级执行；模式名经过排序，同优先级下顺序是确定的。`HasCallback` 和 `GetSubscriberCount` 仍是精确键查询。
-- dead-event handler 在发布找到零个订阅 handler 时触发，先于 middleware。filter 拒绝了事件的订阅者依然算订阅者，不会触发 dead event。它在发布方 goroutine 中同步执行。
+## 质量与性能
 
-## 🗺️ RoadMap
-
-Townbell 会优先保持“进程内、类型安全、轻量事件总线”的定位。后续迭代会参考 Watermill、Blinker、MediatR、Guava EventBus 等项目，但不会把核心库扩成完整的分布式消息系统。
-
-| 优先级 | 是否已完成 | 方向 | 说明 |
-| --- | --- | --- | --- |
-| P0 | 已完成 | 核心正确性 | 发布路径不再持锁执行 handler，修复 `SubscribeOnce` 移除语义和 middleware 执行链，并补充 race test |
-| P0 | 已完成 | API 契约 | 明确 `Publish` / `PublishWithContext` 的错误返回、panic 恢复、同步/异步执行、关闭等边界行为 |
-| P1 | 已完成 | 文档对齐 | README 已补充当前 P1 能力和示例 |
-| P1 | 已完成 | 可观测性 | 已提供 topic / handler 维度的发布数、处理数、失败数、耗时统计，并提供可选 Prometheus 适配 |
-| P1 | 已完成 | 执行控制 | `SubscribeWithOptions` 支持 handler 级 timeout、recover 策略、异步/串行执行和最大并发数 |
-| P1 | 已完成 | 持续集成 | GitHub Actions 在 Go 版本矩阵上执行 build、vet、race 测试、gofmt 门禁和覆盖率下限，并显式 vet `example/` |
-| P1 | 已完成 | 核心零依赖 | Prometheus 适配器拆为独立模块，引入 `bus` 只会带进标准库 |
-| P1 | 已完成 | 可执行文档 | godoc `Example` 函数在 CI 中带输出校验执行，并展示在 pkg.go.dev 上 |
-| P0 | 试运行（v0.6.0） | 订阅 API 收敛 | 一个 `Subscribe(topic, fn, opts...) (*Handle[T], error)` 取代了此前的十个变体。将在 v1.0.0 冻结 |
-| P0 | 试运行（v0.6.0） | handler 错误上报 | handler 变为 `func(ctx, T) error`：业务失败无需 panic 即可进入指标、`ErrorHandler` 和发布返回值。解锁返回值收集。将在 v1.0.0 冻结 |
-| P0 | 试运行（v0.6.0） | `Publish` 错误语义 | `Publish` 返回同步 handler 失败的合并；忽略它依然合法。将在 v1.0.0 冻结 |
-| P2 | 部分完成（v0.9.0） | 返回值收集 | `PublishCollect` 按派发顺序返回每个同步 handler 错误；任意 handler 返回值收集需在 v1 单独设计 |
-| P2 | 已完成 | Topic 增强 | 通配符（`*`）topic、层级 `prefix.*` 模式、以及无订阅者时的 dead-event hook |
-| P2 | 部分完成 | 集成示例 | `net/http` 示例已提供；Gin、CLI、worker 待补充 |
-| P3 | 未完成 | Broker 桥接 | 参考 Watermill，探索 NATS / Kafka / RabbitMQ 适配器；优先放在独立子包，避免拖重核心库 |
-| P3 | 未完成 | Mediator 模式 | 参考 MediatR，按需提供 request / response、command、query、notification 子包 |
-| P4 | 未完成 | 状态型能力 | 评估 sticky event、事件回放、本地持久化等能力；仅在有明确场景时加入 |
-
-## 🏗️ 架构设计
-
-该库采用模块化设计，提高了代码的可维护性：
-
-### 文件结构
-
-- **`types.go`** - 核心类型定义（Priority、EventError、过滤器、中间件）
-- **`interfaces.go`** - 接口定义（BusSubscriber、BusPublisher、BusController、Bus）
-- **`metrics.go`** - 监控和指标功能
-- **`handle.go`** - 订阅句柄管理和内部处理器结构
-- **`bus.go`** - 核心 EventBus 实现
-
-### 接口分离
-
-```go
-// 订阅者接口
-type BusSubscriber[T any] interface {
-    Subscribe(topic string, fn Handler[T], options ...HandlerOption) (*Handle[T], error)
-}
-
-// 发布者接口
-type BusPublisher[T any] interface {
-    Publish(topic string, event T) error
-    PublishWithContext(ctx context.Context, topic string, event T) error
-    PublishWithTimeout(topic string, event T, timeout time.Duration) error
-}
-
-// 可选的详细发布接口
-type BusResultCollector[T any] interface {
-    PublishCollect(topic string, event T) []error
-    PublishCollectWithContext(ctx context.Context, topic string, event T) []error
-    PublishCollectWithTimeout(topic string, event T, timeout time.Duration) []error
-}
-
-// 控制器接口
-type BusController interface {
-    GetMetrics() Metrics
-    SetErrorHandler(handler ErrorHandler)
-    AddMiddleware(middleware EventMiddleware[any])
-    Close() error
-    // ...
-}
-```
-
-### 类型系统
-
-```go
-// 事件处理器
-type Handler[T any] func(ctx context.Context, event T) error
-
-// 事件过滤器
-type EventFilter[T any] func(topic string, event T) bool
-
-// 事件中间件
-type EventMiddleware[T any] func(topic string, event T, next func()) error
-
-// 错误处理器
-type ErrorHandler func(err *EventError)
-
-// 优先级
-type Priority int
-const (
-    PriorityLow Priority = iota
-    PriorityNormal
-    PriorityHigh
-    PriorityCritical
-)
-```
-
-## 🔧 最佳实践
-
-### 1. 事件设计模式
-
-参考业界最佳实践，支持以下事件设计模式：
-
-#### Event Notification（事件通知）
-```go
-type UserCreatedEvent struct {
-    UserID    string    `json:"user_id"`
-    Timestamp time.Time `json:"timestamp"`
-    // 最小化数据，订阅者自行获取详细信息
-}
-```
-
-#### Event-Carried State Transfer（状态传输）
-```go
-type UserUpdatedEvent struct {
-    UserID       string                 `json:"user_id"`
-    Timestamp    time.Time              `json:"timestamp"`
-    OldState     map[string]interface{} `json:"old_state"`
-    NewState     map[string]interface{} `json:"new_state"`
-    ChangedFields []string              `json:"changed_fields"`
-}
-```
-
-### 2. 命名约定
-
-```go
-// 使用点分层级命名
-"user.created"
-"user.updated"
-"user.deleted"
-"order.placed"
-"order.cancelled"
-"payment.processed"
-"payment.failed"
-
-// 或使用命名空间
-"ecommerce.order.created"
-"auth.user.login"
-"notification.email.sent"
-```
-
-### 3. 错误处理策略
-
-```go
-// 设置重试机制
-eventBus.SetErrorHandler(func(err *EventError) {
-    switch err.Err.(type) {
-    case *TemporaryError:
-        // 临时错误，稍后重试
-        retryQueue.Add(err.Topic, err.Event)
-    case *PermanentError:
-        // 永久错误，记录并告警
-        logger.Error("Permanent error", err)
-        alerting.Send(err)
-    default:
-        // 未知错误，记录详情
-        logger.Warn("Unknown error", err)
-    }
-})
-```
-
-### 4. 性能优化
-
-```go
-// 使用异步处理非关键路径
-eventBus.Subscribe("analytics.track", func(ctx context.Context, event UserEvent) error {
-    return analytics.Track(ctx, event) // 非关键的数据统计
-}, bus.HandlerAsync(false))
-
-// 关键路径使用同步处理
-eventBus.Subscribe("payment.validate", func(ctx context.Context, event PaymentEvent) error {
-    return validatePayment(ctx, event) // 关键的支付验证
-})
-
-// 使用过滤器减少不必要的处理
-eventBus.Subscribe("user.activity", handler, bus.HandlerFilter(
-    func(topic string, event UserEvent) bool {
-        return event.IsImportant() // 只处理重要事件
-    }))
-```
-
-## 🔍 与其他库的对比
-
-| 特性 | Townbell | Guava EventBus | RxJava | Node.js EventEmitter |
-|------|---------|----------------|---------|---------------------|
-| 类型安全 | ✅ 泛型 | ✅ | ✅ | ❌ |
-| 异步处理 | ✅ | ❌ | ✅ | ✅ |
-| 优先级 | ✅ | ❌ | ❌ | ❌ |
-| 过滤器 | ✅ | ❌ | ✅ | ❌ |
-| 中间件 | ✅ | ❌ | ✅ | ❌ |
-| 错误处理 | ✅ | ⚠️ | ✅ | ⚠️ |
-| 监控指标 | ✅ | ❌ | ❌ | ❌ |
-| 上下文支持 | ✅ | ❌ | ❌ | ❌ |
-
-## 🧪 测试
-
-运行完整测试套件。Prometheus 适配器是独立模块，需要单独执行：
+CI 在 Go 版本矩阵上执行构建、vet、race test 和格式检查，并对核心模块强制 90% 覆盖率下限。基准测试衡量并行发布；在对延迟做结论前请先在自己的硬件上复测。
 
 ```bash
 go test -race ./...
 (cd prometheus && go test -race ./...)
-```
-
-`example/` 下的文件带有 `//go:build ignore`，`go vet ./...` 会跳过它们，需要逐个显式指定：
-
-```bash
-for f in example/*.go; do go vet "$f"; done
-```
-
-生成测试覆盖率报告：
-
-```bash
-go test -coverprofile=coverage.out ./...
-go tool cover -html=coverage.out -o coverage.html
-```
-
-**当前覆盖率：核心模块 95.5%**，Prometheus 适配器 79.7%。CI 对核心模块设了 90% 的下限门槛，这个数字不会再悄悄漂移。
-
-运行性能测试：
-
-```bash
 go test -bench=. -benchmem
 ```
 
-## 📈 性能
+## 贡献
 
-测试环境：Apple M5（10 核）、Go 1.22.12、darwin/arm64，测量日期 2026-07-27
-（v0.8.0）。所有基准测试都使用 `b.RunParallel`，因此 `ns/op` 是全部核心上的聚合
-成本，不是单 goroutine 延迟。
+欢迎提交 Issue 和 Pull Request。请保持核心模块零依赖；行为变化请补充聚焦测试，并运行上面的质量命令。
 
-| 基准测试 | ns/op | B/op | allocs/op |
-| --- | --- | --- | --- |
-| `SyncPublish`（1 个订阅者） | 350 | 0 | 0 |
-| `AsyncPublish`（1 个订阅者） | 784 | 128 | 1 |
-| `MultipleSubscribers`（10 个订阅者） | 2580 | 0 | 0 |
-| `WithPriority` | 254 | 0 | 0 |
-| `WithFilter` | 63 | 0 | 0 |
-| `ConcurrentSubscribeUnsubscribe` | 2964 | 713 | 14 |
-| `ChannelBaseline`（裸 Go channel） | 49 | 0 | 0 |
+## 许可证
 
-**同步发布零分配。** handler 列表采用 copy-on-write：订阅变更时构建新切片，
-发布路径直接使用当前列表而无需拷贝；无中间件时整套中间件机制与 debug 日志
-调用也会被完全跳过。v0.8.0 把一次同步发布从 839 ns、11 次分配降到 350 ns、
-零分配。
-
-另外两点值得注意：
-
-- **异步发布比同步发布慢，而不是快。** 每次异步派发都要启动 goroutine，并操作
-  `WaitGroup` 和互斥锁。选择异步是为了把慢 handler 挪出发布 goroutine，不是为了
-  提高吞吐。
-- **裸 channel 依然更便宜**——单 goroutine 下约 2 倍。事件总线换来的是扇出、
-  优先级、过滤器、中间件和监控指标；如果你只需要把一个值交给某个已知的
-  goroutine，channel 才是更合适的工具。
-
-不同硬件上的数字会有差异。请自己重跑基准测试，不要直接采信这张表。
-
-## 🤝 贡献
-
-欢迎提交 Issue 和 Pull Request！
-
-1. Fork 这个仓库
-2. 创建你的特性分支 (`git checkout -b feature/amazing-feature`)
-3. 提交你的改动 (`git commit -m 'Add amazing feature'`)
-4. 推送到分支 (`git push origin feature/amazing-feature`)
-5. 开启一个 Pull Request
-
-## 📄 许可证
-
-MIT License - 详见 [LICENSE](LICENSE) 文件
-
-## 🙏 致谢
-
-本项目参考了以下优秀的开源项目和设计模式：
-
-- [Guava EventBus](https://github.com/google/guava) - Java 生态的经典实现
-- [MBassador](https://github.com/bennidi/mbassador) - 高性能 Java EventBus
-- [Node.js EventEmitter](https://nodejs.org/api/events.html) - JavaScript 原生事件系统
-- [Enterprise Integration Patterns](https://www.enterpriseintegrationpatterns.com/) - 企业集成模式 
+[MIT](LICENSE)

--- a/example/README.md
+++ b/example/README.md
@@ -1,208 +1,38 @@
-# Townbell Examples
+# Townbell examples
 
-This directory contains comprehensive examples demonstrating the features and capabilities of the Townbell library.
+Each file is a standalone program. It carries `//go:build ignore`, so it does
+not conflict with the library test suite.
 
-[中文文档](README_ZH.md)
+[中文文档](README_ZH.md) · [Back to the project README](../README.md)
 
-## Requirements
-
-- Go 1.21 or higher
-- All examples use `//go:build ignore` to prevent conflicts when running `go test ./...`
-- Examples must be run individually using `go run filename.go`
-
-## Examples Overview
-
-### 1. `basic_example.go` - Basic Usage
-**What it demonstrates:**
-- Basic event subscription and publishing
-- Type-safe event buses with generics
-- Synchronous and asynchronous handlers
-- Context-based cancellation
-- Multiple subscribers for the same event
-- Once-only event handlers
-- Checking callback existence
-
-**Run with:**
-```bash
-go run basic_example.go
-```
-
-### 2. `advanced_usage.go` - Advanced Features
-**What it demonstrates:**
-- Type-safe event buses with generics
-- Priority-based event processing
-- Event filtering with custom filters
-- Context-based cancellation
-- Error handling and recovery
-- Monitoring and metrics collection
-- Timeout handling
-
-**Run with:**
-```bash
-go run advanced_usage.go
-```
-
-### 3. `middleware_example.go` - Middleware System
-**What it demonstrates:**
-- Request tracking middleware
-- Timing middleware for performance monitoring
-- Rate limiting middleware
-- Middleware chaining and execution order
-
-**Run with:**
-```bash
-go run middleware_example.go
-```
-
-### 4. `e_commerce_example.go` - Real-World Scenario
-**What it demonstrates:**
-- Complex event-driven workflow (e-commerce order processing)
-- Multiple event buses for different domains
-- Service interaction through events
-- Priority-based processing (security, business logic, notifications)
-- Error scenarios and compensation patterns
-
-**Run with:**
-```bash
-go run e_commerce_example.go
-```
-
-### 5. `http_example.go` - net/http Integration
-**What it demonstrates:**
-- Publishing domain events from HTTP handlers
-- Bounding synchronous dispatch with the request context
-- Async subscribers running off the request goroutine
-- Hierarchical (`orders.*`) pattern subscriptions
-- Catching misrouted topics with the dead-event handler
-- Draining async work with `WaitAsync` before shutdown
-
-**Run with:**
-```bash
-go run http_example.go
-```
-
-## Key Concepts Demonstrated
-
-### Type Safety with Generics
-```go
-// Create type-safe event bus
-eventBus := bus.NewTyped[UserEvent]()
-
-// All events must match the specified type
-eventBus.Publish("user.login", UserEvent{...})
-```
-
-### Priority Processing
-```go
-// Critical priority - executes first
-securityHandle := eventBus.SubscribeWithPriority("user.action", 
-    securityHandler, bus.PriorityCritical)
-
-// Low priority - executes last
-analyticsHandle := eventBus.SubscribeWithPriority("user.action", 
-    analyticsHandler, bus.PriorityLow)
-```
-
-### Event Filtering
-```go
-// Only process admin users
-adminHandle := eventBus.SubscribeWithFilter("user.action", handler,
-    func(topic string, event UserEvent) bool {
-        return strings.HasPrefix(event.UserID, "admin_")
-    })
-```
-
-### Context Cancellation
-```go
-ctx, cancel := context.WithCancel(context.Background())
-handle := eventBus.SubscribeWithContext(ctx, "user.session", handler)
-
-// Cancel all subscriptions with this context
-cancel()
-```
-
-### Error Handling
-```go
-eventBus.SetErrorHandler(func(err *bus.EventError) {
-    log.Printf("Event error in topic '%s': %v", err.Topic, err.Err)
-})
-```
-
-### Middleware
-```go
-eventBus.AddMiddleware(func(topic string, event interface{}, next func()) error {
-    // Pre-processing
-    log.Printf("Processing: %s", topic)
-    
-    next() // Execute handlers
-    
-    // Post-processing
-    log.Printf("Completed: %s", topic)
-    return nil
-})
-```
-
-## Running All Examples
-
-To run all examples sequentially:
+## Run one
 
 ```bash
-# Basic usage
-echo "=== Running Basic Example ===" && go run basic_example.go
-
-# Advanced features
-echo "=== Running Advanced Example ===" && go run advanced_usage.go
-
-# Middleware system
-echo "=== Running Middleware Example ===" && go run middleware_example.go
-
-# E-commerce workflow
-echo "=== Running E-commerce Example ===" && go run e_commerce_example.go
+go run worker_example.go
 ```
 
-## Best Practices Demonstrated
+Run commands from this directory; do not use `go run .` because every file is a
+separate `main` package.
 
-1. **Resource Management**: Always use `defer` to unsubscribe handles
-2. **Error Handling**: Set up global error handlers for monitoring
-3. **Performance**: Use appropriate priorities and async processing
-4. **Type Safety**: Leverage generics for compile-time type checking
-5. **Graceful Shutdown**: Always close event buses with `defer eventBus.Close()`
+## Example map
 
-## Performance Considerations
+| File | Scenario | Concepts |
+| --- | --- | --- |
+| `basic_example.go` | First event bus | Typed subscriptions, sync/async work, context, once handlers |
+| `advanced_usage.go` | Dispatch policy | Priority, filters, error handling, timeout, metrics |
+| `middleware_example.go` | Cross-cutting work | Logging, timing, rate limiting, middleware order |
+| `e_commerce_example.go` | Business flow | Domain buses, priorities, failure compensation |
+| `http_example.go` | HTTP service | Request context, patterns, dead events, graceful shutdown |
+| `worker_example.go` | Local background jobs | Async handlers, bounded concurrency, error hook, draining |
 
-- **Sync vs Async**: Use async for non-critical operations
-- **Priority Levels**: Use priorities to ensure critical operations execute first
-- **Filters**: Apply filters to reduce unnecessary processing
-- **Context**: Use context for timeout and cancellation control
-- **Middleware**: Keep middleware lightweight to avoid performance impact
+## Important boundaries
 
-## Common Patterns
+- These are **in-process** examples. `HandlerMaxConcurrency` bounds work in the
+  current process; it is not a durable queue or a multi-process worker system.
+- Check the `error` returned by `Subscribe` and synchronous `Publish` when
+  delivery failures matter. Async failures arrive at `ErrorHandler`.
+- Use `WaitAsync` before an orderly process exit, then `Close` to reject new
+  work and wait for already-started handlers.
 
-### Event Sourcing
-```go
-// Store all events for replay
-eventBus.Subscribe("*", func(event interface{}) {
-    eventStore.Save(event)
-})
-```
-
-### CQRS (Command Query Responsibility Segregation)
-```go
-// Separate command and query handling
-commandBus := bus.NewTyped[Command]()
-queryBus := bus.NewTyped[Query]()
-```
-
-### Saga Pattern
-```go
-// Coordinate distributed transactions
-orderBus.Subscribe("order.created", func(order Order) {
-    // Start saga
-    paymentBus.Publish("payment.process", Payment{...})
-})
-
-paymentBus.Subscribe("payment.failed", func(payment Payment) {
-    // Compensate
-    orderBus.Publish("order.cancel", Order{...})
-})
-``` 
+For API semantics and the smallest copyable snippet, see the
+[main README](../README.md).

--- a/example/README_ZH.md
+++ b/example/README_ZH.md
@@ -1,238 +1,32 @@
 # Townbell 示例
 
-这个目录包含了展示 Townbell 库功能和特性的全面示例。
+每个文件都是独立程序，并带有 `//go:build ignore`，不会与库本身的测试套件冲突。
 
-## 环境要求
+[English](README.md) · [返回项目 README](../README_ZH.md)
 
-- Go 1.21 或更高版本
-- 所有示例使用 `//go:build ignore` 来避免运行 `go test ./...` 时发生冲突
-- 示例必须单独运行，使用 `go run filename.go`
-
-## 示例概览
-
-### 1. `basic_example.go` - 基础用法
-**演示内容：**
-- 基本事件订阅和发布
-- 使用泛型的类型安全事件总线
-- 同步和异步处理器
-- 基于上下文的取消
-- 同一事件的多个订阅者
-- 一次性事件处理器
-- 检查回调是否存在
-
-**运行方式：**
-```bash
-go run basic_example.go
-```
-
-### 2. `advanced_usage.go` - 高级功能
-**演示内容：**
-- 使用泛型的类型安全事件总线
-- 基于优先级的事件处理
-- 使用自定义过滤器的事件过滤
-- 基于上下文的取消
-- 错误处理和恢复
-- 监控和指标收集
-- 超时处理
-
-**运行方式：**
-```bash
-go run advanced_usage.go
-```
-
-### 3. `middleware_example.go` - 中间件系统
-**演示内容：**
-- 请求跟踪中间件
-- 性能监控的计时中间件
-- 限流中间件
-- 中间件链和执行顺序
-
-**运行方式：**
-```bash
-go run middleware_example.go
-```
-
-### 4. `e_commerce_example.go` - 真实世界场景
-**演示内容：**
-- 复杂事件驱动工作流（电商订单处理）
-- 不同领域的多个事件总线
-- 通过事件进行服务交互
-- 基于优先级的处理（安全、业务逻辑、通知）
-- 错误场景和补偿模式
-
-**运行方式：**
-```bash
-go run e_commerce_example.go
-```
-
-### 5. `http_example.go` - net/http 集成
-**演示内容：**
-- 在 HTTP handler 中发布领域事件
-- 用请求 context 约束同步派发
-- 异步订阅者在请求 goroutine 之外运行
-- 层级（`orders.*`）模式订阅
-- 用 dead-event handler 捕获投错的 topic
-- 退出前用 `WaitAsync` 排干异步工作
-
-**运行方式：**
-```bash
-go run http_example.go
-```
-
-## 核心概念演示
-
-### 使用泛型的类型安全
-```go
-// 创建类型安全的事件总线
-eventBus := bus.NewTyped[UserEvent]()
-
-// 所有事件必须匹配指定类型
-eventBus.Publish("user.login", UserEvent{...})
-```
-
-### 优先级处理
-```go
-// 关键优先级 - 最先执行
-securityHandle := eventBus.SubscribeWithPriority("user.action", 
-    securityHandler, bus.PriorityCritical)
-
-// 低优先级 - 最后执行
-analyticsHandle := eventBus.SubscribeWithPriority("user.action", 
-    analyticsHandler, bus.PriorityLow)
-```
-
-### 事件过滤
-```go
-// 只处理管理员用户
-adminHandle := eventBus.SubscribeWithFilter("user.action", handler,
-    func(topic string, event UserEvent) bool {
-        return strings.HasPrefix(event.UserID, "admin_")
-    })
-```
-
-### 上下文取消
-```go
-ctx, cancel := context.WithCancel(context.Background())
-handle := eventBus.SubscribeWithContext(ctx, "user.session", handler)
-
-// 取消所有使用此上下文的订阅
-cancel()
-```
-
-### 错误处理
-```go
-eventBus.SetErrorHandler(func(err *bus.EventError) {
-    log.Printf("主题 '%s' 中的事件错误: %v", err.Topic, err.Err)
-})
-```
-
-### 中间件
-```go
-eventBus.AddMiddleware(func(topic string, event interface{}, next func()) error {
-    // 预处理
-    log.Printf("处理中: %s", topic)
-    
-    next() // 执行处理器
-    
-    // 后处理
-    log.Printf("完成: %s", topic)
-    return nil
-})
-```
-
-## 运行所有示例
-
-按顺序运行所有示例：
+## 运行一个示例
 
 ```bash
-# 基础用法
-echo "=== 运行基础示例 ===" && go run basic_example.go
-
-# 高级功能
-echo "=== 运行高级示例 ===" && go run advanced_usage.go
-
-# 中间件系统
-echo "=== 运行中间件示例 ===" && go run middleware_example.go
-
-# 电商工作流
-echo "=== 运行电商示例 ===" && go run e_commerce_example.go
+go run worker_example.go
 ```
 
-## 演示的最佳实践
+请在当前目录执行命令；不要使用 `go run .`，因为每个文件都是独立的 `main` 包。
 
-1. **资源管理**: 总是使用 `defer` 来取消订阅句柄
-2. **错误处理**: 设置全局错误处理器进行监控
-3. **性能**: 使用适当的优先级和异步处理
-4. **类型安全**: 利用泛型进行编译时类型检查
-5. **优雅关闭**: 总是使用 `defer eventBus.Close()` 关闭事件总线
+## 示例地图
 
-## 性能考虑
+| 文件 | 场景 | 涵盖概念 |
+| --- | --- | --- |
+| `basic_example.go` | 第一个事件总线 | 类型安全订阅、同步/异步、context、一次性 handler |
+| `advanced_usage.go` | 派发策略 | 优先级、过滤、错误处理、超时、指标 |
+| `middleware_example.go` | 横切逻辑 | 日志、计时、限流、中间件顺序 |
+| `e_commerce_example.go` | 业务流程 | 领域总线、优先级、失败补偿 |
+| `http_example.go` | HTTP 服务 | 请求 context、模式、dead event、优雅关闭 |
+| `worker_example.go` | 本地后台任务 | 异步 handler、限并发、错误钩子、排空 |
 
-- **同步 vs 异步**: 对非关键操作使用异步
-- **优先级**: 使用优先级确保关键操作优先执行
-- **过滤器**: 应用过滤器减少不必要的处理
-- **上下文**: 使用上下文进行超时和取消控制
-- **中间件**: 保持中间件轻量以避免性能影响
+## 重要边界
 
-## 常见模式
+- 这些都是**进程内**示例。`HandlerMaxConcurrency` 限制的是当前进程的工作量；它不是持久化队列，也不是多进程 worker 系统。
+- 当派发失败会影响业务结果时，请检查 `Subscribe` 和同步 `Publish` 返回的 `error`。异步失败会进入 `ErrorHandler`。
+- 进程有序退出前使用 `WaitAsync` 排空已启动的异步工作；再调用 `Close` 拒绝新工作并等待已有 handler。
 
-### 事件溯源
-```go
-// 存储所有事件以便重放
-eventBus.Subscribe("*", func(event interface{}) {
-    eventStore.Save(event)
-})
-```
-
-### CQRS (命令查询责任分离)
-```go
-// 分离命令和查询处理
-commandBus := bus.NewTyped[Command]()
-queryBus := bus.NewTyped[Query]()
-```
-
-### Saga 模式
-```go
-// 协调分布式事务
-orderBus.Subscribe("order.created", func(order Order) {
-    // 开始 saga
-    paymentBus.Publish("payment.process", Payment{...})
-})
-
-paymentBus.Subscribe("payment.failed", func(payment Payment) {
-    // 补偿
-    orderBus.Publish("order.cancel", Order{...})
-})
-```
-
-## 故障排除
-
-### 常见问题
-
-1. **构建错误**: 如果遇到 "main redeclared" 错误，确保使用 `go run filename.go` 而不是 `go run .`
-2. **导入错误**: 确保你的项目有正确的 `go.mod` 文件
-3. **版本兼容性**: 确保使用 Go 1.21 或更高版本
-
-### 调试技巧
-
-```go
-// 启用详细日志
-eventBus.AddMiddleware(func(topic string, event interface{}, next func()) error {
-    fmt.Printf("DEBUG: 处理事件 %s: %+v\n", topic, event)
-    next()
-    return nil
-})
-
-// 检查订阅者数量
-fmt.Printf("主题 '%s' 的订阅者数量: %d\n", topic, eventBus.GetSubscriberCount(topic))
-
-// 获取所有主题
-fmt.Printf("所有主题: %v\n", eventBus.GetTopics())
-```
-
-## 进一步学习
-
-- 查看主项目的 [README.md](../README.md) 了解完整的 API 文档
-- 查看 [README_ZH.md](../README_ZH.md) 了解中文版本的完整文档
-- 查看源代码了解实现细节
-- 运行基准测试了解性能特征: `go test -bench=. -benchmem` 
+完整 API 语义和最小可复制代码请看[项目 README](../README_ZH.md)。

--- a/example/worker_example.go
+++ b/example/worker_example.go
@@ -1,0 +1,64 @@
+//go:build ignore
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync/atomic"
+	"time"
+
+	"github.com/townbell/bus"
+)
+
+// EmailJob is a unit of background work produced by the application.
+type EmailJob struct {
+	ID string
+}
+
+func main() {
+	eventBus := bus.NewTyped[EmailJob]()
+	defer eventBus.Close()
+
+	eventBus.SetErrorHandler(func(eventErr *bus.EventError) {
+		log.Printf("job %q failed: %v", eventErr.Topic, eventErr.Err)
+	})
+
+	var active int32
+	var peak int32
+	_, err := eventBus.Subscribe("email.send", func(ctx context.Context, job EmailJob) error {
+		current := atomic.AddInt32(&active, 1)
+		defer atomic.AddInt32(&active, -1)
+		for {
+			previous := atomic.LoadInt32(&peak)
+			if current <= previous || atomic.CompareAndSwapInt32(&peak, previous, current) {
+				break
+			}
+		}
+
+		select {
+		case <-time.After(100 * time.Millisecond):
+			fmt.Println("sent", job.ID)
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	},
+		bus.HandlerAsync(false),
+		bus.HandlerMaxConcurrency(2),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i := 1; i <= 5; i++ {
+		if err := eventBus.Publish("email.send", EmailJob{ID: fmt.Sprintf("email-%d", i)}); err != nil {
+			log.Printf("enqueue email-%d: %v", i, err)
+		}
+	}
+
+	// WaitAsync drains already-started background handlers before the process exits.
+	eventBus.WaitAsync()
+	fmt.Println("peak concurrent jobs:", atomic.LoadInt32(&peak))
+}


### PR DESCRIPTION
## Summary

- Reorganize the English and Chinese READMEs around the project boundary, dispatch model, quick start, and scenario-based example navigation.
- Add a runnable in-process worker example that demonstrates asynchronous delivery, bounded concurrency, error reporting, and graceful draining.
- Replace obsolete subscription API references in the example guides.

## Why

The previous READMEs were lengthy and the example index still referenced removed subscription helpers. This makes the supported API and the in-process worker pattern easier to discover without expanding the core package.

## Impact

- No runtime library behavior or dependencies change.
- The new worker sample is intentionally in-process; it is not a durable queue or multi-process worker system.
- Both English and Chinese documentation remain aligned.

## Validation

- `GOCACHE=/private/tmp/go-bus-gocache go test -race ./...`
- `(cd prometheus && GOCACHE=/private/tmp/go-bus-gocache GOMODCACHE=/private/tmp/go-bus-gomodcache go test -race -ldflags='-linkmode=external' ./...)`
- Vet and build every file in `example/`.
- `go run -ldflags='-linkmode=external' example/worker_example.go` (observed peak concurrency: 2).
