### PR TITLE
fix: stabilize v0.11.1 lifecycle and metrics

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -8,10 +8,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// EventBus - box for handlers and callbacks.
+// EventBus dispatches events to topic subscribers.
+//
+// EventBus is safe for concurrent use by multiple goroutines.
 type EventBus[T any] struct {
 	handlers map[string][]*eventHandler[T]
 	// patternTopics tracks the handler-map keys that are patterns ("*" or a
@@ -26,8 +29,11 @@ type EventBus[T any] struct {
 	wg               sync.WaitGroup
 	closed           bool
 	closeCh          chan struct{}
-	nextHandlerID    uint64
 }
+
+// handlerIDSequence gives handler metrics a process-wide identity. This keeps
+// per-handler Prometheus series distinct when several buses share a registry.
+var handlerIDSequence atomic.Uint64
 
 // Option defines a functional option for EventBus
 type Option[T any] func(*EventBus[T])
@@ -117,7 +123,7 @@ func New(opts ...Option[any]) *EventBus[any] {
 // returned handle is nil; a nil handle is still safe to use.
 func (bus *EventBus[T]) Subscribe(topic string, fn Handler[T], options ...HandlerOption) (*Handle[T], error) {
 	if fn == nil {
-		return nil, fmt.Errorf("event handler is nil")
+		return nil, ErrNilHandler
 	}
 
 	opts := defaultHandlerOptions()
@@ -153,12 +159,13 @@ func (bus *EventBus[T]) Subscribe(topic string, fn Handler[T], options ...Handle
 		maxConcurrency: opts.maxConcurrency,
 		Mutex:          sync.Mutex{},
 	}
+	handler.active.Store(true)
 
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
 
 	if bus.closed {
-		return nil, fmt.Errorf("event bus is closed")
+		return nil, ErrBusClosed
 	}
 	bus.prepareHandlerLocked(topic, handler)
 
@@ -211,20 +218,23 @@ func topicMatchesPattern(pattern, topic string) bool {
 }
 
 func (bus *EventBus[T]) prepareHandlerLocked(topic string, handler *eventHandler[T]) {
-	bus.nextHandlerID++
-	handler.id = topic + "#" + strconv.FormatUint(bus.nextHandlerID, 10)
+	handler.id = topic + "#" + strconv.FormatUint(handlerIDSequence.Add(1), 10)
 	if handler.maxConcurrency > 0 && handler.concurrency == nil {
 		handler.concurrency = make(chan struct{}, handler.maxConcurrency)
 	}
 }
 
-// HasCallback returns true if exists any callback subscribed to the topic.
+// HasCallback reports whether topic has an exact or matching-pattern subscription.
 func (bus *EventBus[T]) HasCallback(topic string) bool {
 	bus.lock.RLock()
 	defer bus.lock.RUnlock()
-	_, ok := bus.handlers[topic]
-	if ok {
-		return len(bus.handlers[topic]) > 0
+	if len(bus.handlers[topic]) > 0 {
+		return true
+	}
+	for pattern := range bus.patternTopics {
+		if topicMatchesPattern(pattern, topic) && len(bus.handlers[pattern]) > 0 {
+			return true
+		}
 	}
 	return false
 }
@@ -267,7 +277,7 @@ func (bus *EventBus[T]) PublishCollectWithContext(ctx context.Context, topic str
 	bus.lock.RLock()
 	if bus.closed {
 		bus.lock.RUnlock()
-		return []error{fmt.Errorf("event bus is closed")}
+		return []error{ErrBusClosed}
 	}
 	logger := bus.logger
 	errorHandler := bus.errorHandler
@@ -350,13 +360,23 @@ func runMiddlewares(middlewares []EventMiddleware[any], topic string, event any,
 			dispatchErrs = dispatch()
 			return
 		}
-		var nextOnce sync.Once
+		var nextMu sync.Mutex
+		nextCalled := false
+		middlewareReturned := false
 		next := func() {
-			nextOnce.Do(func() {
-				run(i + 1)
-			})
+			nextMu.Lock()
+			defer nextMu.Unlock()
+			if middlewareReturned || nextCalled {
+				return
+			}
+			nextCalled = true
+			run(i + 1)
 		}
-		if err := middlewares[i](topic, event, next); err != nil {
+		err := middlewares[i](topic, event, next)
+		nextMu.Lock()
+		middlewareReturned = true
+		nextMu.Unlock()
+		if err != nil {
 			middlewareErr = err
 		}
 	}
@@ -372,7 +392,7 @@ func (bus *EventBus[T]) dispatchCollect(ctx context.Context, topic string, event
 		case <-ctx.Done():
 			return append(errs, ctx.Err())
 		case <-closeCh:
-			return append(errs, fmt.Errorf("event bus is closed"))
+			return append(errs, ErrBusClosed)
 		default:
 		}
 
@@ -404,7 +424,7 @@ func (bus *EventBus[T]) dispatchCollect(ctx context.Context, topic string, event
 		}
 
 		if !bus.addAsync() {
-			return append(errs, fmt.Errorf("event bus is closed"))
+			return append(errs, ErrBusClosed)
 		}
 		if handler.transactional {
 			handler.Lock()
@@ -459,6 +479,7 @@ func (bus *EventBus[T]) doPublish(ctx context.Context, closeCh <-chan struct{}, 
 		ctx = context.Background()
 	}
 
+	bus.beginHandlerMetrics(handler)
 	start := time.Now()
 	err := bus.runHandler(ctx, closeCh, handler, event)
 	duration := time.Since(start)
@@ -468,9 +489,7 @@ func (bus *EventBus[T]) doPublish(ctx context.Context, closeCh <-chan struct{}, 
 			logger.Debug("Handler executed successfully for topic '%s'", topic)
 		}
 		metrics.IncrementProcessed()
-		if detailed, ok := metrics.(DetailedMetrics); ok {
-			detailed.RecordProcessed(topic, handler.id, duration)
-		}
+		bus.recordHandlerMetrics(metrics, handler, topic, duration, false)
 		return nil, false
 	}
 
@@ -492,9 +511,7 @@ func (bus *EventBus[T]) doPublish(ctx context.Context, closeCh <-chan struct{}, 
 		})
 	}
 	metrics.IncrementFailed()
-	if detailed, ok := metrics.(DetailedMetrics); ok {
-		detailed.RecordFailed(topic, handler.id, duration)
-	}
+	bus.recordHandlerMetrics(metrics, handler, topic, duration, true)
 	return err, isPanic && handler.recoverPolicy == RecoverAndStop
 }
 
@@ -505,7 +522,7 @@ func (bus *EventBus[T]) runHandler(ctx context.Context, closeCh <-chan struct{},
 	}
 
 	if !bus.addAsync() {
-		return fmt.Errorf("event bus is closed")
+		return ErrBusClosed
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -530,7 +547,7 @@ func (bus *EventBus[T]) runHandler(ctx context.Context, closeCh <-chan struct{},
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-closeCh:
-		return fmt.Errorf("event bus is closed")
+		return ErrBusClosed
 	}
 }
 
@@ -562,7 +579,7 @@ func acquireConcurrency[T any](ctx context.Context, closeCh <-chan struct{}, han
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-closeCh:
-		return fmt.Errorf("event bus is closed")
+		return ErrBusClosed
 	}
 }
 
@@ -585,9 +602,9 @@ func (bus *EventBus[T]) doPublishAsync(handler *eventHandler[T], topic string, e
 
 func (bus *EventBus[T]) removeHandler(topic string, target *eventHandler[T]) bool {
 	bus.lock.Lock()
-	defer bus.lock.Unlock()
 
 	if _, ok := bus.handlers[topic]; !ok {
+		bus.lock.Unlock()
 		return false
 	}
 
@@ -595,6 +612,7 @@ func (bus *EventBus[T]) removeHandler(topic string, target *eventHandler[T]) boo
 		if handler != target {
 			continue
 		}
+		target.active.Store(false)
 		// Copy-on-write: build a fresh slice so publishes holding the old one
 		// keep a consistent view without copying on their hot path.
 		old := bus.handlers[topic]
@@ -613,9 +631,48 @@ func (bus *EventBus[T]) removeHandler(topic string, target *eventHandler[T]) boo
 		if bus.logger != nil {
 			bus.logger.Debug("Handler removed from topic '%s'", topic)
 		}
+		bus.lock.Unlock()
+		bus.removeHandlerMetrics(target)
 		return true
 	}
+	bus.lock.Unlock()
 	return false
+}
+
+func (bus *EventBus[T]) beginHandlerMetrics(handler *eventHandler[T]) {
+	handler.metricsMu.Lock()
+	defer handler.metricsMu.Unlock()
+	handler.metricsInFlight++
+}
+
+func (bus *EventBus[T]) recordHandlerMetrics(metrics Metrics, handler *eventHandler[T], topic string, duration time.Duration, failed bool) {
+	handler.metricsMu.Lock()
+	defer handler.metricsMu.Unlock()
+
+	if detailed, ok := metrics.(DetailedMetrics); ok {
+		if failed {
+			detailed.RecordFailed(topic, handler.id, duration)
+		} else {
+			detailed.RecordProcessed(topic, handler.id, duration)
+		}
+	}
+	handler.metricsInFlight--
+	if handler.metricsCleanupPending && handler.metricsInFlight == 0 {
+		if cleaner, ok := metrics.(HandlerMetricsCleaner); ok {
+			cleaner.RemoveHandlerMetrics(handler.topic, handler.id)
+		}
+	}
+}
+
+func (bus *EventBus[T]) removeHandlerMetrics(handler *eventHandler[T]) {
+	handler.metricsMu.Lock()
+	defer handler.metricsMu.Unlock()
+	handler.metricsCleanupPending = true
+	if handler.metricsInFlight == 0 {
+		if cleaner, ok := bus.metrics.(HandlerMetricsCleaner); ok {
+			cleaner.RemoveHandlerMetrics(handler.topic, handler.id)
+		}
+	}
 }
 
 // WaitAsync waits for all async callbacks to complete
@@ -668,7 +725,7 @@ func (bus *EventBus[T]) GetLogger() Logger {
 	return bus.logger
 }
 
-// GetTopics returns all topics that have subscribers
+// GetTopics returns all topics that have subscribers in lexical order.
 func (bus *EventBus[T]) GetTopics() []string {
 	bus.lock.RLock()
 	defer bus.lock.RUnlock()
@@ -677,6 +734,7 @@ func (bus *EventBus[T]) GetTopics() []string {
 	for topic := range bus.handlers {
 		topics = append(topics, topic)
 	}
+	sort.Strings(topics)
 	return topics
 }
 
@@ -697,18 +755,27 @@ func (bus *EventBus[T]) Close() error {
 
 	if bus.closed {
 		bus.lock.Unlock()
-		return fmt.Errorf("event bus already closed")
+		return fmt.Errorf("%w: already closed", ErrBusClosed)
 	}
 
 	bus.closed = true
 	close(bus.closeCh)
 	subscriberCount := 0
+	removedHandlers := make([]*eventHandler[T], 0)
 	for _, handlers := range bus.handlers {
 		subscriberCount += len(handlers)
+		for _, handler := range handlers {
+			handler.active.Store(false)
+			removedHandlers = append(removedHandlers, handler)
+		}
 	}
 	bus.handlers = make(map[string][]*eventHandler[T])
 	bus.patternTopics = make(map[string]struct{})
 	bus.lock.Unlock()
+
+	for _, handler := range removedHandlers {
+		bus.removeHandlerMetrics(handler)
+	}
 
 	// Wait for all async operations to complete
 	bus.wg.Wait()

--- a/bus_test.go
+++ b/bus_test.go
@@ -587,6 +587,31 @@ func TestMiddlewareNextIsConcurrentSafe(t *testing.T) {
 	}
 }
 
+func TestMiddlewareNextAfterReturnIsIgnored(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	nexts := make(chan func(), 1)
+	var handlerCalled int32
+	bus.AddMiddleware(func(topic string, event interface{}, next func()) error {
+		nexts <- next
+		return nil
+	})
+	mustSubscribe(t, bus, "middleware.next.late", func(ctx context.Context, event TestEvent) error {
+		atomic.AddInt32(&handlerCalled, 1)
+		return nil
+	})
+
+	if err := bus.Publish("middleware.next.late", TestEvent{ID: "test", Value: 1}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	(<-nexts)()
+
+	if count := atomic.LoadInt32(&handlerCalled); count != 0 {
+		t.Fatalf("Expected late next to be ignored, got %d handler calls", count)
+	}
+}
+
 func TestPublishDoesNotHoldBusLockDuringHandler(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 	defer bus.Close()
@@ -886,6 +911,23 @@ func TestHandleUnsubscribe(t *testing.T) {
 	}
 }
 
+func TestHandleBecomesInactiveAfterOnceDelivery(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	handle := mustSubscribe(t, bus, "once.handle", discard[TestEvent], HandlerOnce())
+	if err := bus.Publish("once.handle", TestEvent{ID: "once"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	if handle.IsActive() {
+		t.Fatal("once handle should be inactive after delivery")
+	}
+	if err := handle.Unsubscribe(); !errors.Is(err, ErrSubscriptionInactive) {
+		t.Fatalf("Unsubscribe error = %v, want ErrSubscriptionInactive", err)
+	}
+}
+
 func TestBusClose(t *testing.T) {
 	bus := NewTyped[TestEvent]()
 
@@ -906,8 +948,8 @@ func TestBusClose(t *testing.T) {
 	}
 
 	// Try to publish again (should fail)
-	if err := bus.PublishWithContext(context.Background(), "close.test", TestEvent{ID: "after_close", Value: 2}); err == nil {
-		t.Error("Expected error when publishing to closed bus")
+	if err := bus.PublishWithContext(context.Background(), "close.test", TestEvent{ID: "after_close", Value: 2}); !errors.Is(err, ErrBusClosed) {
+		t.Errorf("Publish error = %v, want ErrBusClosed", err)
 	}
 
 	// Try to subscribe (should fail)
@@ -916,8 +958,23 @@ func TestBusClose(t *testing.T) {
 	}
 
 	// Closing again should return error
-	if err := bus.Close(); err == nil {
-		t.Error("Expected error when closing already closed bus")
+	if err := bus.Close(); !errors.Is(err, ErrBusClosed) {
+		t.Errorf("second Close error = %v, want ErrBusClosed", err)
+	}
+}
+
+func TestHandleBecomesInactiveAfterClose(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	handle := mustSubscribe(t, bus, "close.handle", discard[TestEvent])
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if handle.IsActive() {
+		t.Fatal("handle should be inactive after Close")
+	}
+	if err := handle.Unsubscribe(); !errors.Is(err, ErrSubscriptionInactive) {
+		t.Fatalf("Unsubscribe error = %v, want ErrSubscriptionInactive", err)
 	}
 }
 
@@ -1301,6 +1358,19 @@ func TestHasCallback(t *testing.T) {
 	}
 }
 
+func TestHasCallbackMatchesPatternSubscriptions(t *testing.T) {
+	bus := NewTyped[TestEvent]()
+	defer bus.Close()
+
+	mustSubscribe(t, bus, "orders.*", discard[TestEvent])
+	if !bus.HasCallback("orders.created") {
+		t.Fatal("expected matching pattern subscription")
+	}
+	if bus.HasCallback("orders") {
+		t.Fatal("pattern must not match its prefix topic")
+	}
+}
+
 // TestGetTopics tests the GetTopics function
 func TestGetTopics(t *testing.T) {
 	bus := NewTyped[TestEvent]()
@@ -1325,6 +1395,11 @@ func TestGetTopics(t *testing.T) {
 	topics = bus.GetTopics()
 	if len(topics) != 3 {
 		t.Errorf("Expected 3 topics, got %d", len(topics))
+	}
+	for i, expected := range []string{"topic1", "topic2", "topic3"} {
+		if topics[i] != expected {
+			t.Fatalf("Expected sorted topics %v, got %v", []string{"topic1", "topic2", "topic3"}, topics)
+		}
 	}
 
 	// Check if all topics are present

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,9 @@
+// Package bus provides a dependency-free, type-safe event bus for in-process
+// event dispatch.
+//
+// An EventBus is safe for concurrent use by multiple goroutines. Publish
+// delivers events synchronously by default; subscriptions may opt into
+// asynchronous delivery, priority, filtering, timeouts, and panic recovery.
+// User-supplied handlers and implementations of optional interfaces such as
+// Metrics and Logger must be safe for the concurrency enabled by a bus.
+package bus

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,14 @@
+package bus
+
+import "errors"
+
+var (
+	// ErrBusClosed reports an operation attempted after an EventBus was closed.
+	ErrBusClosed = errors.New("event bus is closed")
+	// ErrNilHandler reports an attempt to subscribe a nil handler.
+	ErrNilHandler = errors.New("event handler is nil")
+	// ErrNilHandle reports an operation attempted on a nil subscription handle.
+	ErrNilHandle = errors.New("handle is nil: the subscription was never created")
+	// ErrSubscriptionInactive reports an operation attempted on an inactive subscription.
+	ErrSubscriptionInactive = errors.New("subscription is inactive")
+)

--- a/handle.go
+++ b/handle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -21,21 +22,26 @@ type Handle[T any] struct {
 // error from Subscribe and deferring Unsubscribe stays safe.
 func (h *Handle[T]) Unsubscribe() error {
 	if h == nil {
-		return fmt.Errorf("handle is nil: the subscription was never created")
+		return ErrNilHandle
 	}
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	if h.handler == nil {
-		return fmt.Errorf("handle already unsubscribed")
+		return ErrSubscriptionInactive
+	}
+	if !h.handler.active.Load() {
+		h.handler = nil
+		return ErrSubscriptionInactive
 	}
 
-	if h.bus.logger != nil {
-		h.bus.logger.Debug("Unsubscribing handler from topic '%s'", h.topic)
+	if logger := h.bus.GetLogger(); logger != nil {
+		logger.Debug("Unsubscribing handler from topic '%s'", h.topic)
 	}
 	if !h.bus.removeHandler(h.topic, h.handler) {
-		return fmt.Errorf("handler not found for topic %s", h.topic)
+		h.handler = nil
+		return fmt.Errorf("%w: handler not found for topic %s", ErrSubscriptionInactive, h.topic)
 	}
 	h.handler = nil
 
@@ -51,23 +57,27 @@ func (h *Handle[T]) IsActive() bool {
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return h.handler != nil
+	return h.handler != nil && h.handler.active.Load()
 }
 
 // eventHandler represents an internal event handler
 type eventHandler[T any] struct {
-	id             string
-	topic          string
-	callBack       Handler[T]
-	flagOnce       bool
-	async          bool
-	transactional  bool
-	priority       Priority
-	filter         EventFilter[T]
-	ctx            context.Context
-	timeout        time.Duration
-	recoverPolicy  RecoverPolicy
-	maxConcurrency int
-	concurrency    chan struct{}
-	sync.Mutex     // lock for an event handler - useful for running async callbacks serially
+	id                    string
+	topic                 string
+	callBack              Handler[T]
+	flagOnce              bool
+	async                 bool
+	transactional         bool
+	priority              Priority
+	filter                EventFilter[T]
+	ctx                   context.Context
+	timeout               time.Duration
+	recoverPolicy         RecoverPolicy
+	maxConcurrency        int
+	concurrency           chan struct{}
+	active                atomic.Bool
+	metricsMu             sync.Mutex
+	metricsInFlight       int
+	metricsCleanupPending bool
+	sync.Mutex            // lock for an event handler - useful for running async callbacks serially
 }

--- a/handle_test.go
+++ b/handle_test.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"sync"
 	"testing"
 )
 
@@ -67,4 +68,30 @@ func TestHandleUnsubscribeIsIdempotent(t *testing.T) {
 	if err := handle.Unsubscribe(); err == nil {
 		t.Error("second Unsubscribe returned no error")
 	}
+}
+
+func TestHandleUnsubscribeConcurrentWithSetLogger(t *testing.T) {
+	bus := NewTyped[string](WithLogger[string](NewNoOpLogger()))
+	defer bus.Close()
+	handle := mustSubscribe(t, bus, "topic", discard[string])
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 100; i++ {
+			bus.SetLogger(NewNoOpLogger())
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 100; i++ {
+			_ = handle.Unsubscribe()
+		}
+	}()
+	close(start)
+	wg.Wait()
 }

--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync/atomic"
 )
 
 // LogLevel represents the severity level of a log message
@@ -50,62 +51,64 @@ type Logger interface {
 
 // DefaultLogger is the default logger implementation using Go's standard log package
 type DefaultLogger struct {
-	level  LogLevel
+	level  atomic.Int32
 	logger *log.Logger
 }
 
 // NewDefaultLogger creates a new default logger instance
 func NewDefaultLogger() *DefaultLogger {
-	return &DefaultLogger{
-		level:  LogLevelInfo,
+	logger := &DefaultLogger{
 		logger: log.New(os.Stdout, "[EventBus] ", log.LstdFlags|log.Lshortfile),
 	}
+	logger.level.Store(int32(LogLevelInfo))
+	return logger
 }
 
 // NewDefaultLoggerWithOutput creates a new default logger with custom output
 func NewDefaultLoggerWithOutput(output *os.File, prefix string) *DefaultLogger {
-	return &DefaultLogger{
-		level:  LogLevelInfo,
+	logger := &DefaultLogger{
 		logger: log.New(output, prefix, log.LstdFlags|log.Lshortfile),
 	}
+	logger.level.Store(int32(LogLevelInfo))
+	return logger
 }
 
 // Debug logs a debug message
 func (l *DefaultLogger) Debug(msg string, args ...interface{}) {
-	if l.level <= LogLevelDebug {
+	if LogLevel(l.level.Load()) <= LogLevelDebug {
 		l.logger.Printf("[%s] %s", LogLevelDebug.String(), fmt.Sprintf(msg, args...))
 	}
 }
 
 // Info logs an info message
 func (l *DefaultLogger) Info(msg string, args ...interface{}) {
-	if l.level <= LogLevelInfo {
+	if LogLevel(l.level.Load()) <= LogLevelInfo {
 		l.logger.Printf("[%s] %s", LogLevelInfo.String(), fmt.Sprintf(msg, args...))
 	}
 }
 
 // Warn logs a warning message
 func (l *DefaultLogger) Warn(msg string, args ...interface{}) {
-	if l.level <= LogLevelWarn {
+	if LogLevel(l.level.Load()) <= LogLevelWarn {
 		l.logger.Printf("[%s] %s", LogLevelWarn.String(), fmt.Sprintf(msg, args...))
 	}
 }
 
 // Error logs an error message
 func (l *DefaultLogger) Error(msg string, args ...interface{}) {
-	if l.level <= LogLevelError {
+	if LogLevel(l.level.Load()) <= LogLevelError {
 		l.logger.Printf("[%s] %s", LogLevelError.String(), fmt.Sprintf(msg, args...))
 	}
 }
 
 // SetLevel sets the minimum log level
 func (l *DefaultLogger) SetLevel(level LogLevel) {
-	l.level = level
+	l.level.Store(int32(level))
 }
 
 // GetLevel returns the current log level
 func (l *DefaultLogger) GetLevel() LogLevel {
-	return l.level
+	return LogLevel(l.level.Load())
 }
 
 // NoOpLogger is a logger that does nothing (useful for disabling logging)

--- a/logger_test.go
+++ b/logger_test.go
@@ -283,6 +283,23 @@ func TestLoggerConcurrency(t *testing.T) {
 	}
 }
 
+func TestDefaultLoggerLevelConcurrency(t *testing.T) {
+	logger := NewDefaultLogger()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				logger.SetLevel(LogLevel((i + j) % 4))
+				_ = logger.GetLevel()
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
 func BenchmarkEventBusWithLogger(b *testing.B) {
 	eventBus := NewTyped[string]()
 	eventBus.SetLogger(NewDefaultLogger())

--- a/metrics.go
+++ b/metrics.go
@@ -24,6 +24,14 @@ type DetailedMetrics interface {
 	RecordFailed(topic, handlerID string, duration time.Duration)
 }
 
+// HandlerMetricsCleaner is an optional Metrics extension for discarding
+// per-handler data when a subscription becomes inactive.
+//
+// Implementations should retain aggregate topic and global metrics.
+type HandlerMetricsCleaner interface {
+	RemoveHandlerMetrics(topic, handlerID string)
+}
+
 // TopicMetricsSnapshot is a read-only copy of metrics for a topic.
 type TopicMetricsSnapshot struct {
 	PublishedEvents int64
@@ -70,6 +78,7 @@ type DefaultMetrics struct {
 }
 
 var _ DetailedMetrics = (*DefaultMetrics)(nil)
+var _ HandlerMetricsCleaner = (*DefaultMetrics)(nil)
 
 func (m *DefaultMetrics) IncrementPublished() {
 	atomic.AddInt64(&m.PublishedEvents, 1)
@@ -166,6 +175,13 @@ func (m *DefaultMetrics) GetHandlerStats() map[string]HandlerMetricsSnapshot {
 		}
 	}
 	return result
+}
+
+// RemoveHandlerMetrics discards per-handler metrics for an inactive subscription.
+func (m *DefaultMetrics) RemoveHandlerMetrics(_ string, handlerID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.handlerMetrics, handlerID)
 }
 
 func (m *DefaultMetrics) ensureMaps() {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -191,3 +191,119 @@ func TestDefaultMetricsDetailedSnapshots(t *testing.T) {
 		t.Fatalf("Expected handler processed=1 failed=1, got processed=%d failed=%d", handlerStats.ProcessedEvents, handlerStats.FailedEvents)
 	}
 }
+
+func TestDetailedHandlerMetricsAreRemovedWithSubscription(t *testing.T) {
+	bus := NewTyped[string]()
+	defer bus.Close()
+
+	handle := mustSubscribe(t, bus, "orders.created", discard[string])
+	if err := bus.Publish("orders.created", "o-1"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	detailed := bus.GetMetrics().(*DefaultMetrics)
+	if got := len(detailed.GetHandlerStats()); got != 1 {
+		t.Fatalf("Expected one handler metric before unsubscribe, got %d", got)
+	}
+	if err := handle.Unsubscribe(); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+	if got := len(detailed.GetHandlerStats()); got != 0 {
+		t.Fatalf("Expected handler metrics to be removed after unsubscribe, got %d", got)
+	}
+}
+
+func TestDetailedHandlerMetricsAreRemovedAfterOnceDelivery(t *testing.T) {
+	bus := NewTyped[string]()
+	defer bus.Close()
+
+	mustSubscribe(t, bus, "orders.once", discard[string], HandlerOnce())
+	if err := bus.Publish("orders.once", "o-1"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	detailed := bus.GetMetrics().(*DefaultMetrics)
+	if got := len(detailed.GetHandlerStats()); got != 0 {
+		t.Fatalf("Expected once handler metrics to be removed, got %d", got)
+	}
+}
+
+func TestDetailedHandlerMetricsAreRemovedOnClose(t *testing.T) {
+	bus := NewTyped[string]()
+	mustSubscribe(t, bus, "orders.close", discard[string])
+	if err := bus.Publish("orders.close", "o-1"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	detailed := bus.GetMetrics().(*DefaultMetrics)
+	if got := len(detailed.GetHandlerStats()); got != 1 {
+		t.Fatalf("Expected one handler metric before Close, got %d", got)
+	}
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := len(detailed.GetHandlerStats()); got != 0 {
+		t.Fatalf("Expected handler metrics to be removed after Close, got %d", got)
+	}
+}
+
+func TestDetailedTopicMetricsSurviveInFlightUnsubscribe(t *testing.T) {
+	bus := NewTyped[string]()
+	defer bus.Close()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handle := mustSubscribe(t, bus, "orders.unsubscribe", func(context.Context, string) error {
+		close(started)
+		<-release
+		return nil
+	}, HandlerAsync(false))
+	if err := bus.Publish("orders.unsubscribe", "o-1"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	<-started
+	if err := handle.Unsubscribe(); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+	close(release)
+	bus.WaitAsync()
+
+	detailed := bus.GetMetrics().(*DefaultMetrics)
+	if got := detailed.GetTopicStats()["orders.unsubscribe"].ProcessedEvents; got != 1 {
+		t.Fatalf("Expected one topic metric after in-flight unsubscribe, got %d", got)
+	}
+	if got := len(detailed.GetHandlerStats()); got != 0 {
+		t.Fatalf("Expected handler metrics to be removed after unsubscribe, got %d", got)
+	}
+}
+
+func TestDetailedTopicMetricsSurviveInFlightClose(t *testing.T) {
+	bus := NewTyped[string]()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mustSubscribe(t, bus, "orders.close-in-flight", func(context.Context, string) error {
+		close(started)
+		<-release
+		return nil
+	}, HandlerAsync(false))
+	if err := bus.Publish("orders.close-in-flight", "o-1"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	<-started
+
+	closed := make(chan error, 1)
+	go func() { closed <- bus.Close() }()
+	close(release)
+	if err := <-closed; err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	detailed := bus.GetMetrics().(*DefaultMetrics)
+	if got := detailed.GetTopicStats()["orders.close-in-flight"].ProcessedEvents; got != 1 {
+		t.Fatalf("Expected one topic metric after in-flight Close, got %d", got)
+	}
+	if got := len(detailed.GetHandlerStats()); got != 0 {
+		t.Fatalf("Expected handler metrics to be removed after Close, got %d", got)
+	}
+}

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -33,6 +33,7 @@ type Metrics struct {
 }
 
 var _ bus.DetailedMetrics = (*Metrics)(nil)
+var _ bus.HandlerMetricsCleaner = (*Metrics)(nil)
 
 // New creates a Prometheus-backed metrics collector.
 func New(config Config) *Metrics {
@@ -200,4 +201,14 @@ func (m *Metrics) GetTopicStats() map[string]bus.TopicMetricsSnapshot {
 
 func (m *Metrics) GetHandlerStats() map[string]bus.HandlerMetricsSnapshot {
 	return m.base.GetHandlerStats()
+}
+
+// RemoveHandlerMetrics removes metric series for an inactive subscription.
+// Aggregate topic and global metrics remain available.
+func (m *Metrics) RemoveHandlerMetrics(topic, handlerID string) {
+	m.base.RemoveHandlerMetrics(topic, handlerID)
+	m.processedHandle.DeleteLabelValues(topic, handlerID)
+	m.failedHandle.DeleteLabelValues(topic, handlerID)
+	m.duration.DeleteLabelValues(topic, handlerID, "success")
+	m.duration.DeleteLabelValues(topic, handlerID, "failed")
 }

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -64,3 +64,94 @@ func TestMetricsReusesAlreadyRegisteredCollectors(t *testing.T) {
 		t.Fatalf("Expected one registered topic metric, got %d", count)
 	}
 }
+
+func TestMetricsRemovesHandlerSeriesOnUnsubscribe(t *testing.T) {
+	registry := client.NewRegistry()
+	metrics := New(Config{Namespace: "test", Subsystem: "cleanup", Registerer: registry})
+	eventBus := bus.NewTyped[string](bus.WithMetrics[string](metrics))
+	defer eventBus.Close()
+
+	handle, err := eventBus.Subscribe("topic", func(ctx context.Context, event string) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := eventBus.Publish("topic", "event"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if count := testutil.CollectAndCount(metrics.processedHandle); count != 1 {
+		t.Fatalf("Expected one handler series before unsubscribe, got %d", count)
+	}
+	if err := handle.Unsubscribe(); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+	if count := testutil.CollectAndCount(metrics.processedHandle); count != 0 {
+		t.Fatalf("Expected no handler series after unsubscribe, got %d", count)
+	}
+}
+
+func TestMetricsKeepsOtherBusHandlerSeriesOnUnsubscribe(t *testing.T) {
+	registry := client.NewRegistry()
+	first := New(Config{Namespace: "test", Subsystem: "shared", Registerer: registry})
+	second := New(Config{Namespace: "test", Subsystem: "shared", Registerer: registry})
+	firstBus := bus.NewTyped[string](bus.WithMetrics[string](first))
+	secondBus := bus.NewTyped[string](bus.WithMetrics[string](second))
+	defer firstBus.Close()
+	defer secondBus.Close()
+
+	firstHandle, err := firstBus.Subscribe("topic", func(context.Context, string) error { return nil })
+	if err != nil {
+		t.Fatalf("First Subscribe: %v", err)
+	}
+	if _, err := secondBus.Subscribe("topic", func(context.Context, string) error { return nil }); err != nil {
+		t.Fatalf("Second Subscribe: %v", err)
+	}
+	if err := firstBus.Publish("topic", "first"); err != nil {
+		t.Fatalf("First Publish: %v", err)
+	}
+	if err := secondBus.Publish("topic", "second"); err != nil {
+		t.Fatalf("Second Publish: %v", err)
+	}
+	if count := testutil.CollectAndCount(first.processedHandle); count != 2 {
+		t.Fatalf("Expected two handler series before unsubscribe, got %d", count)
+	}
+	if err := firstHandle.Unsubscribe(); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+	if count := testutil.CollectAndCount(first.processedHandle); count != 1 {
+		t.Fatalf("Expected second bus handler series to remain, got %d", count)
+	}
+}
+
+func TestMetricsRemovesHandlerSeriesAfterOnceAndClose(t *testing.T) {
+	registry := client.NewRegistry()
+	metrics := New(Config{Namespace: "test", Subsystem: "once_close", Registerer: registry})
+	eventBus := bus.NewTyped[string](bus.WithMetrics[string](metrics))
+
+	if _, err := eventBus.Subscribe("once", func(context.Context, string) error { return nil }, bus.HandlerOnce()); err != nil {
+		t.Fatalf("Subscribe once: %v", err)
+	}
+	if err := eventBus.Publish("once", "event"); err != nil {
+		t.Fatalf("Publish once: %v", err)
+	}
+	if count := testutil.CollectAndCount(metrics.processedHandle); count != 0 {
+		t.Fatalf("Expected no handler series after once delivery, got %d", count)
+	}
+
+	if _, err := eventBus.Subscribe("close", func(context.Context, string) error { return nil }); err != nil {
+		t.Fatalf("Subscribe close: %v", err)
+	}
+	if err := eventBus.Publish("close", "event"); err != nil {
+		t.Fatalf("Publish close: %v", err)
+	}
+	if count := testutil.CollectAndCount(metrics.processedHandle); count != 1 {
+		t.Fatalf("Expected one handler series before Close, got %d", count)
+	}
+	if err := eventBus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if count := testutil.CollectAndCount(metrics.processedHandle); count != 0 {
+		t.Fatalf("Expected no handler series after Close, got %d", count)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -49,7 +49,10 @@ type DeadEventHandler[T any] func(topic string, event T)
 // EventFilter allows filtering events before they reach handlers
 type EventFilter[T any] func(topic string, event T) bool
 
-// EventMiddleware allows intercepting events before and after processing
+// EventMiddleware allows intercepting events before and after processing.
+//
+// A middleware that wants dispatch to continue must call next before it
+// returns. Calling next after the middleware returns is ignored.
 type EventMiddleware[T any] func(topic string, event T, next func()) error
 
 // ErrorHandler defines how to handle errors during event processing


### PR DESCRIPTION
## Summary

- prevent late middleware next calls from racing dispatch state
- make handles inactive after once delivery or bus close, with sentinel errors
- retain aggregate metrics while cleaning inactive handler series, including shared Prometheus registries
- make logger levels and logger replacement safe under concurrent use

## Verification

- go test -race -count=1 ./...
- go vet ./...
- go test -count=1 -cover ./... (96.2%)
- go test -race -count=1 -ldflags=external ./... in prometheus/
- Gin example build
- middleware race and handle lifecycle reproductions